### PR TITLE
perf: Add React.memo and Zustand shallow selectors for render optimization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import { useGameStore } from './store/gameStore'
 import { HexGrid } from './components/Board/HexGrid'
 import { GameOver } from './components/Game/GameOver'
@@ -73,7 +74,35 @@ function App() {
     selectTileMoveSource,
     applyTileMove,
     undoLastAction,
-  } = useGameStore()
+  } = useGameStore(useShallow((s) => ({
+    board: s.board,
+    players: s.players,
+    currentPlayerIndex: s.currentPlayerIndex,
+    phase: s.phase,
+    currentTerrainCard: s.currentTerrainCard,
+    remainingPlacements: s.remainingPlacements,
+    validPlacements: s.validPlacements,
+    selectedCell: s.selectedCell,
+    objectiveCards: s.objectiveCards,
+    finalScores: s.finalScores,
+    activeTile: s.activeTile,
+    tileMoveSources: s.tileMoveSources,
+    tileMoveFrom: s.tileMoveFrom,
+    tileMoveDestinations: s.tileMoveDestinations,
+    history: s.history,
+    canUndo: s.canUndo,
+    initGame: s.initGame,
+    drawTerrainCard: s.drawTerrainCard,
+    placeSettlement: s.placeSettlement,
+    endTurn: s.endTurn,
+    selectCell: s.selectCell,
+    activateTile: s.activateTile,
+    cancelTile: s.cancelTile,
+    applyTilePlacement: s.applyTilePlacement,
+    selectTileMoveSource: s.selectTileMoveSource,
+    applyTileMove: s.applyTileMove,
+    undoLastAction: s.undoLastAction,
+  })))
 
   const multiplayerMode = useMultiplayerStore((s) => s.mode);
   const multiplayerRoom = useMultiplayerStore((s) => s.room);

--- a/src/components/Board/HexCell.tsx
+++ b/src/components/Board/HexCell.tsx
@@ -23,7 +23,7 @@ interface HexCellProps {
   cellRef?: (el: SVGGElement | null) => void;
 }
 
-export const HexCell: React.FC<HexCellProps> = ({
+export const HexCell: React.FC<HexCellProps> = React.memo(({
   cell,
   isValid,
   isSelected,
@@ -132,4 +132,6 @@ export const HexCell: React.FC<HexCellProps> = ({
       )}
     </g>
   );
-};
+});
+
+HexCell.displayName = 'HexCell';

--- a/src/components/Board/HexGrid.tsx
+++ b/src/components/Board/HexGrid.tsx
@@ -15,7 +15,7 @@ interface HexGridProps {
   onEscape?: () => void;
 }
 
-export const HexGrid: React.FC<HexGridProps> = ({
+export const HexGrid: React.FC<HexGridProps> = React.memo(({
   board,
   validPlacements,
   selectedCell,
@@ -259,4 +259,6 @@ export const HexGrid: React.FC<HexGridProps> = ({
       </div>
     </div>
   );
-};
+});
+
+HexGrid.displayName = 'HexGrid';

--- a/src/components/Game/GameLog.tsx
+++ b/src/components/Game/GameLog.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { GameAction } from '../../types/history';
 import { Player } from '../../types';
 import { Location } from '../../core/terrain';
@@ -39,7 +40,7 @@ const LOCATION_EMOJI: Partial<Record<Location, string>> = {
   [Location.Tavern]: '🍺',
 };
 
-export function GameLog({ history, players }: GameLogProps) {
+export const GameLog = React.memo(function GameLog({ history, players }: GameLogProps) {
   const recent = [...history].reverse().slice(0, MAX_LOG_ENTRIES);
 
   if (recent.length === 0) {
@@ -79,4 +80,4 @@ export function GameLog({ history, players }: GameLogProps) {
       </ul>
     </div>
   );
-}
+});

--- a/src/components/Game/GameOver.tsx
+++ b/src/components/Game/GameOver.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { PlayerScore } from '../../types';
 import { ObjectiveCard } from '../../core/scoring';
 import { Player } from '../../types';
@@ -9,7 +10,7 @@ interface GameOverProps {
   onNewGame: () => void;
 }
 
-export function GameOver({
+export const GameOver = React.memo(function GameOver({
   finalScores,
   players,
   objectiveCards,
@@ -84,4 +85,4 @@ export function GameOver({
       </div>
     </div>
   );
-}
+});


### PR DESCRIPTION
## Summary

- Wrap `HexCell`, `HexGrid`, `GameOver`, `GameLog` with `React.memo` to skip re-renders when parent state changes do not affect their props
- Add `displayName` to memo-wrapped arrow function components for DevTools clarity
- Replace the bare `useGameStore()` call in `App.tsx` with `useShallow` selector so the component only re-renders when the subscribed slice actually changes, not on every store write

## Test plan

- [ ] Run existing test suite: `npm test`
- [ ] Start dev server and play a full game — verify board renders correctly, settlements place correctly, tile actions work
- [ ] Verify GameLog updates as actions are taken
- [ ] Verify GameOver modal appears with correct scores at end of game

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)