### PR TITLE
Add settings audio controls

### DIFF
--- a/src/components/Menu/MainMenu.tsx
+++ b/src/components/Menu/MainMenu.tsx
@@ -19,6 +19,8 @@ import {
 import { LeaderboardModal } from '../Game/LeaderboardModal';
 import { ReplayModal } from '../Game/ReplayModal';
 import { AchievementPanel } from '../Game/AchievementPanel';
+import { SettingsModal } from './SettingsModal';
+import { getVolume, setVolume } from '../../utils/soundEngine';
 
 interface MainMenuProps {
   muted: boolean;
@@ -38,7 +40,9 @@ export function MainMenu({
   onLanguageChange,
 }: MainMenuProps) {
   const { t, i18n } = useTranslation();
-  const [hasSave] = useState(() => loadGame() !== null);
+  const [hasSave, setHasSave] = useState(() => loadGame() !== null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [volume, setVolumeState] = useState(() => getVolume());
   const [leaderboardOpen, setLeaderboardOpen] = useState(false);
   const [replayOpen, setReplayOpen] = useState(false);
   const [achievementOpen, setAchievementOpen] = useState(false);
@@ -52,6 +56,12 @@ export function MainMenu({
 
   const handleClearSave = () => {
     clearSave();
+    setHasSave(false);
+  };
+
+  const handleVolumeChange = (nextVolume: number) => {
+    setVolume(nextVolume);
+    setVolumeState(nextVolume);
   };
 
   return (
@@ -90,7 +100,7 @@ export function MainMenu({
         </button>
 
         <button
-          onClick={() => {}}
+          onClick={() => setSettingsOpen(true)}
           aria-label={t('menu.settings')}
           title={t('menu.settings')}
           className="w-9 h-9 flex items-center justify-center rounded-full transition"
@@ -271,6 +281,16 @@ export function MainMenu({
       <LeaderboardModal isOpen={leaderboardOpen} onClose={() => setLeaderboardOpen(false)} />
       <ReplayModal isOpen={replayOpen} onClose={() => setReplayOpen(false)} />
       {achievementOpen && <AchievementPanel onClose={() => setAchievementOpen(false)} />}
+      <SettingsModal
+        isOpen={settingsOpen}
+        muted={muted}
+        volume={volume}
+        language={i18n.language}
+        onClose={() => setSettingsOpen(false)}
+        onToggleMute={onToggleMute}
+        onVolumeChange={handleVolumeChange}
+        onLanguageChange={onLanguageChange}
+      />
     </div>
   );
 }

--- a/src/components/Menu/SettingsModal.tsx
+++ b/src/components/Menu/SettingsModal.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { CloseIcon, MutedIcon, UnmutedIcon } from '../icons';
+
+interface SettingsModalProps {
+  isOpen: boolean;
+  muted: boolean;
+  volume: number;
+  language: string;
+  onClose: () => void;
+  onToggleMute: () => void;
+  onVolumeChange: (volume: number) => void;
+  onLanguageChange: (language: string) => void;
+}
+
+export const SettingsModal = React.memo(function SettingsModal({
+  isOpen,
+  muted,
+  volume,
+  language,
+  onClose,
+  onToggleMute,
+  onVolumeChange,
+  onLanguageChange,
+}: SettingsModalProps) {
+  const { t } = useTranslation();
+
+  if (!isOpen) return null;
+
+  const volumePercent = Math.round(volume * 100);
+
+  return (
+    <div className="fixed inset-0 z-[60] bg-black/70 flex items-center justify-center px-4">
+      <div
+        className="bg-white rounded-xl shadow-2xl p-6 max-w-md w-full"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="settings-heading"
+      >
+        <div className="flex items-center justify-between gap-3 mb-5">
+          <h3 id="settings-heading" className="text-2xl font-bold text-gray-900">
+            {t('settings.heading')}
+          </h3>
+          <button
+            onClick={onClose}
+            className="w-9 h-9 rounded-full flex items-center justify-center text-gray-600 hover:bg-gray-100 hover:text-gray-900 transition"
+            aria-label={t('settings.close')}
+            title={t('settings.close')}
+          >
+            <CloseIcon size={18} />
+          </button>
+        </div>
+
+        <div className="space-y-5">
+          <section aria-labelledby="settings-audio-heading" className="space-y-3">
+            <h4 id="settings-audio-heading" className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+              {t('settings.audio')}
+            </h4>
+
+            <button
+              type="button"
+              onClick={onToggleMute}
+              aria-pressed={muted}
+              className="w-full flex items-center justify-between gap-3 rounded-lg border border-gray-200 px-4 py-3 text-left hover:bg-gray-50 transition"
+            >
+              <span className="flex items-center gap-2 font-semibold text-gray-900">
+                {muted ? <MutedIcon size={18} /> : <UnmutedIcon size={18} />}
+                {t('settings.mute')}
+              </span>
+              <span className="text-sm text-gray-600">
+                {muted ? t('settings.muted') : t('settings.unmuted')}
+              </span>
+            </button>
+
+            <label className="block" htmlFor="settings-volume">
+              <span className="flex items-center justify-between text-sm font-semibold text-gray-700 mb-2">
+                <span>{t('settings.volume')}</span>
+                <span>{t('settings.volumeValue', { value: volumePercent })}</span>
+              </span>
+              <input
+                id="settings-volume"
+                aria-label={t('settings.volume')}
+                type="range"
+                min="0"
+                max="100"
+                step="5"
+                value={volumePercent}
+                onChange={(event) => onVolumeChange(Number(event.target.value) / 100)}
+                className="w-full accent-blue-600"
+              />
+            </label>
+          </section>
+
+          <section aria-labelledby="settings-language-heading" className="space-y-2">
+            <h4 id="settings-language-heading" className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+              {t('settings.language')}
+            </h4>
+            <select
+              value={language}
+              onChange={(event) => onLanguageChange(event.target.value)}
+              aria-label={t('common.language')}
+              className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm text-gray-900 bg-white"
+            >
+              <option value="en">{t('common.english')}</option>
+              <option value="zh-TW">{t('common.traditionalChinese')}</option>
+            </select>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -59,6 +59,17 @@ export const en = {
     settings: 'Settings',
     back: 'Back',
   },
+  settings: {
+    heading: 'Settings',
+    close: 'Close settings',
+    audio: 'Audio',
+    mute: 'Mute sound',
+    muted: 'Muted',
+    unmuted: 'On',
+    volume: 'Volume',
+    volumeValue: '{{value}}%',
+    language: 'Language',
+  },
   multiplayer: {
     serverUrl: 'Server URL',
     yourName: 'Your Name',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -59,6 +59,17 @@ export const zhTW = {
     settings: '設定',
     back: '返回',
   },
+  settings: {
+    heading: '設定',
+    close: '關閉設定',
+    audio: '音訊',
+    mute: '靜音',
+    muted: '已靜音',
+    unmuted: '開啟',
+    volume: '音量',
+    volumeValue: '{{value}}%',
+    language: '語言',
+  },
   multiplayer: {
     serverUrl: '伺服器網址',
     yourName: '你的名稱',

--- a/src/utils/soundEngine.test.ts
+++ b/src/utils/soundEngine.test.ts
@@ -36,7 +36,7 @@ function makeMockAudioContext() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const MockAudioContext = vi.fn(function (this: unknown): any { return instance; });
 
-  return { MockAudioContext, instance };
+  return { MockAudioContext, instance, mockGain };
 }
 
 describe('soundEngine', () => {
@@ -65,6 +65,35 @@ describe('soundEngine', () => {
       setMuted(false);
       expect(localStorage.getItem('kingdom-builder-muted')).toBe('false');
       expect(isMuted()).toBe(false);
+    });
+  });
+
+  describe('getVolume / setVolume', () => {
+    it('defaults to full volume', async () => {
+      const { getVolume } = await import('./soundEngine');
+      expect(getVolume()).toBe(1);
+    });
+
+    it('stores clamped volume values in localStorage', async () => {
+      const { getVolume, setVolume } = await import('./soundEngine');
+
+      setVolume(0.35);
+      expect(localStorage.getItem('kingdom-builder-volume')).toBe('0.35');
+      expect(getVolume()).toBe(0.35);
+
+      setVolume(2);
+      expect(getVolume()).toBe(1);
+
+      setVolume(-1);
+      expect(getVolume()).toBe(0);
+    });
+
+    it('falls back to full volume for invalid stored values', async () => {
+      const { getVolume } = await import('./soundEngine');
+
+      localStorage.setItem('kingdom-builder-volume', 'loud');
+
+      expect(getVolume()).toBe(1);
     });
   });
 
@@ -117,6 +146,19 @@ describe('soundEngine', () => {
       playSound(SoundType.PLACE);
 
       expect(instance.createOscillator).toHaveBeenCalled();
+    });
+
+    it('applies the configured volume to playback gain', async () => {
+      const { MockAudioContext, mockGain } = makeMockAudioContext();
+      vi.stubGlobal('AudioContext', MockAudioContext);
+      const { initAudio, playSound, setMuted, setVolume, SoundType } = await import('./soundEngine');
+      initAudio();
+
+      setMuted(false);
+      setVolume(0.5);
+      playSound(SoundType.PLACE);
+
+      expect(mockGain.gain.setValueAtTime).toHaveBeenCalledWith(0.15, 0);
     });
   });
 });

--- a/src/utils/soundEngine.ts
+++ b/src/utils/soundEngine.ts
@@ -7,6 +7,7 @@ export enum SoundType {
 }
 
 const MUTE_STORAGE_KEY = 'kingdom-builder-muted';
+const VOLUME_STORAGE_KEY = 'kingdom-builder-volume';
 
 let audioCtx: AudioContext | null = null;
 
@@ -25,6 +26,19 @@ export function isMuted(): boolean {
 
 export function setMuted(muted: boolean): void {
   localStorage.setItem(MUTE_STORAGE_KEY, String(muted));
+}
+
+export function getVolume(): number {
+  const raw = localStorage.getItem(VOLUME_STORAGE_KEY);
+  if (raw === null) return 1;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return 1;
+  return Math.min(1, Math.max(0, parsed));
+}
+
+export function setVolume(volume: number): void {
+  const clamped = Math.min(1, Math.max(0, volume));
+  localStorage.setItem(VOLUME_STORAGE_KEY, String(clamped));
 }
 
 function getContext(): AudioContext | null {
@@ -49,7 +63,7 @@ function playTone(
   osc.type = type;
   osc.frequency.setValueAtTime(frequency, startTime);
 
-  gain.gain.setValueAtTime(gainValue, startTime);
+  gain.gain.setValueAtTime(gainValue * getVolume(), startTime);
   gain.gain.exponentialRampToValueAtTime(0.001, startTime + duration);
 
   osc.connect(gain);
@@ -99,7 +113,7 @@ export function playSound(type: SoundType): void {
         osc.frequency.setValueAtTime(440, now);
         osc.frequency.linearRampToValueAtTime(220, now + 0.2);
 
-        gain.gain.setValueAtTime(0.3, now);
+        gain.gain.setValueAtTime(0.3 * getVolume(), now);
         gain.gain.exponentialRampToValueAtTime(0.001, now + 0.2);
 
         osc.connect(gain);

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('i18nextLng', 'en');
+  });
+});
+
+test('settings: opens from main menu and persists audio controls', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Settings' }).click();
+
+  const dialog = page.getByRole('dialog', { name: 'Settings' });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText('Audio')).toBeVisible();
+
+  const muteButton = dialog.getByRole('button', { name: /Mute sound/i });
+  await expect(muteButton).toHaveAttribute('aria-pressed', 'false');
+  await muteButton.click();
+  await expect(muteButton).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.evaluate(() => localStorage.getItem('kingdom-builder-muted'))).resolves.toBe('true');
+
+  const volumeSlider = dialog.getByRole('slider', { name: 'Volume' });
+  await volumeSlider.fill('35');
+  await expect(page.evaluate(() => localStorage.getItem('kingdom-builder-volume'))).resolves.toBe('0.35');
+  await expect(dialog.getByText('35%')).toBeVisible();
+
+  await dialog.getByRole('button', { name: 'Close settings' }).click();
+  await expect(dialog).toBeHidden();
+});
+
+test('settings: language selector updates the main menu language', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Settings' }).click();
+  const dialog = page.getByRole('dialog');
+  await dialog.getByRole('combobox', { name: 'Language' }).selectOption('zh-TW');
+
+  await expect(page.getByRole('heading', { name: '王國建造者' })).toBeVisible();
+  await expect(dialog.getByRole('heading', { name: '設定' })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- Wire the main menu Settings button to a functional modal
- Add persisted mute, volume, and language controls in the settings panel
- Apply saved volume to sound playback and keep Clear Save UI state current

## Verification
- npm run lint
- npm run build
- npm test -- --run
- npx playwright test --project=chromium --retries=0
- node ~/HurricaneCore/eye/dist/cli.js detect-changes --staged --human