### PR TITLE
Add mobile drawer game info

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173';
+const devServerUrl = new URL(baseURL);
+const devServerPort = devServerUrl.port || (devServerUrl.protocol === 'https:' ? '443' : '80');
+const devServerHost = devServerUrl.hostname;
+
 /**
  * Playwright configuration for Kingdom Builder E2E tests.
  * Targets Chromium, Firefox, and WebKit; starts the Vite dev server
@@ -28,7 +33,7 @@ export default defineConfig({
 
   use: {
     /* Base URL to use in actions such as `await page.goto('/')`. */
-    baseURL: 'http://localhost:5173',
+    baseURL,
 
     /* Collect trace when retrying the failed test. */
     trace: 'on-first-retry',
@@ -58,9 +63,9 @@ export default defineConfig({
 
   /* Automatically start the Vite dev server before tests */
   webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:5173',
-    reuseExistingServer: !process.env.CI,
+    command: `npm run dev -- --host ${devServerHost} --port ${devServerPort} --strictPort`,
+    url: baseURL,
+    reuseExistingServer: process.env.PLAYWRIGHT_REUSE_EXISTING === '1',
     timeout: 30_000,
   },
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1156,7 +1156,11 @@ function App() {
           onToggle={() => setDrawerOpen(o => !o)}
           phase={phase}
           currentPlayer={currentPlayer}
+          players={players}
           currentTerrainCard={currentTerrainCard}
+          objectiveCards={objectiveCards}
+          liveScores={liveScores}
+          maxLiveScore={maxLiveScore}
           remainingPlacements={remainingPlacements}
           activeTile={activeTile}
           tileMoveFrom={tileMoveFrom}

--- a/src/components/Game/TurnBanner.tsx
+++ b/src/components/Game/TurnBanner.tsx
@@ -76,7 +76,7 @@ export const TurnBanner: React.FC<TurnBannerProps> = ({
         >
           {phaseLabel}
           {terrainLabel && ` · ${terrainLabel}`}
-          {phase === GamePhase.PlaceSettlements && validPlacements.length === 0 && ` · 無可放置位置`}
+          {phase === GamePhase.PlaceSettlements && validPlacements.length === 0 && ` · ${t('turnBanner.noValidPlacements')}`}
         </span>
 
         {/* Progress bar (only during PlaceSettlements) */}

--- a/src/components/Mobile/BottomDrawer.tsx
+++ b/src/components/Mobile/BottomDrawer.tsx
@@ -3,8 +3,9 @@ import { GamePhase } from '../../types';
 import { Location } from '../../core/terrain';
 import { Player, LocationTile } from '../../types';
 import { GameAction } from '../../types/history';
+import type { ObjectiveCard } from '../../core/scoring';
 import { useTranslation } from 'react-i18next';
-import { tLocation, tPhase, tTerrain } from '../../i18n/formatters';
+import { tLocation, tObjective, tPhase, tTerrain } from '../../i18n/formatters';
 import {
   CastleIcon,
   FarmIcon,
@@ -36,7 +37,15 @@ interface BottomDrawerProps {
   /** Game state props */
   phase: GamePhase;
   currentPlayer: Player | undefined;
+  players: Player[];
   currentTerrainCard: { terrain: import('../../core/terrain').Terrain } | null;
+  objectiveCards: ObjectiveCard[];
+  liveScores: Array<{
+    playerId: number;
+    castle: number;
+    objectives: Array<{ card: ObjectiveCard; score: number }>;
+  }>;
+  maxLiveScore: number;
   remainingPlacements: number;
   activeTile: Location | null;
   tileMoveFrom: import('../../core/hex').AxialCoord | null;
@@ -55,8 +64,8 @@ interface BottomDrawerProps {
  * Groups content to mirror the desktop Sidebar structure:
  *   A) Current terrain card
  *   B) Location tiles
- *   C) Objectives (not passed via props — omitted in drawer)
- *   D) Live scores (not passed via props — omitted in drawer)
+ *   C) Objectives
+ *   D) Live scores
  *   E) Players summary
  */
 export const BottomDrawer: React.FC<BottomDrawerProps> = ({
@@ -64,7 +73,11 @@ export const BottomDrawer: React.FC<BottomDrawerProps> = ({
   onToggle,
   phase,
   currentPlayer,
+  players,
   currentTerrainCard,
+  objectiveCards,
+  liveScores,
+  maxLiveScore,
   remainingPlacements,
   activeTile,
   tileMoveFrom,
@@ -323,6 +336,109 @@ export const BottomDrawer: React.FC<BottomDrawerProps> = ({
                     : t('bottomDrawer.tapHighlightedCellToPlace')}
                 </div>
               )}
+            </section>
+          )}
+
+          {/* ── Group C: Objective Cards ── */}
+          {objectiveCards.length > 0 && (
+            <section
+              aria-label={t('sidebar.objectives')}
+              className="rounded-xl overflow-hidden"
+              style={{ border: '1px solid var(--card-border)' }}
+            >
+              <div
+                className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider"
+                style={{
+                  backgroundColor: 'var(--color-warm-cream-100)',
+                  color: 'var(--color-stone-600)',
+                  borderBottom: '1px solid var(--card-border)',
+                }}
+              >
+                {t('sidebar.objectives')}
+              </div>
+              <div className="p-3 flex flex-wrap gap-2" style={{ backgroundColor: 'var(--color-surface)' }}>
+                {objectiveCards.map(card => (
+                  <span
+                    key={card}
+                    className="px-3 py-1.5 text-xs font-semibold rounded-lg"
+                    style={{
+                      backgroundColor: 'var(--color-player-blue)',
+                      color: 'var(--color-warm-cream-50)',
+                    }}
+                  >
+                    {tObjective(t, card)}
+                  </span>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* ── Group D: Live Scores ── */}
+          {liveScores.length > 0 && phase !== GamePhase.Setup && (
+            <section
+              aria-label={t('sidebar.liveScores')}
+              className="rounded-xl overflow-hidden"
+              style={{ border: '1px solid var(--card-border)' }}
+            >
+              <div
+                className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider"
+                style={{
+                  backgroundColor: 'var(--color-warm-cream-100)',
+                  color: 'var(--color-stone-600)',
+                  borderBottom: '1px solid var(--card-border)',
+                }}
+              >
+                {t('sidebar.liveScores')}
+              </div>
+              <div className="p-3 space-y-2" style={{ backgroundColor: 'var(--color-surface)' }}>
+                {liveScores.map(playerScore => {
+                  const player = players.find(p => p.id === playerScore.playerId);
+                  const total = playerScore.castle + playerScore.objectives.reduce((sum, objective) => sum + objective.score, 0);
+                  const isLeader = total === maxLiveScore && total > 0;
+
+                  return (
+                    <div
+                      key={playerScore.playerId}
+                      className="rounded-lg p-2"
+                      style={{
+                        border: `2px solid ${isLeader ? 'var(--color-amber-400)' : 'var(--card-border)'}`,
+                        backgroundColor: isLeader ? 'oklch(0.97 0.02 80)' : 'var(--color-warm-cream-50)',
+                      }}
+                    >
+                      <div className="flex justify-between items-center text-sm font-medium">
+                        <div className="flex items-center gap-1.5 min-w-0">
+                          <div
+                            className="w-3 h-3 rounded-full flex-shrink-0"
+                            style={{ backgroundColor: player?.color ?? '#ccc' }}
+                            aria-hidden="true"
+                          />
+                          <span className="truncate" style={{ color: 'var(--color-text)' }}>{player?.name}</span>
+                          {isLeader && (
+                            <span className="text-xs" title={t('bottomDrawer.leading')}>★</span>
+                          )}
+                        </div>
+                        <span
+                          className="font-bold flex-shrink-0"
+                          style={{ color: isLeader ? 'var(--color-amber-700)' : 'var(--color-text)' }}
+                        >
+                          {total} {t('common.pointsShort')}
+                        </span>
+                      </div>
+                      <p className="text-xs mt-0.5" style={{ color: 'var(--color-stone-400)' }}>
+                        {t('app.castleScoreSummary', {
+                          castle: playerScore.castle,
+                          objectives: playerScore.objectives
+                            .map(objective => t('app.objectiveScoreItem', {
+                              card: tObjective(t, objective.card),
+                              score: objective.score,
+                            }))
+                            .join(' | '),
+                        })}
+                      </p>
+                    </div>
+                  );
+                })}
+              </div>
             </section>
           )}
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -237,6 +237,7 @@ export const en = {
     phaseLabel: 'Phase',
     placementsProgress: '{{placed}} of {{total}} settlements placed',
     ofSettlements: '{{placed}} of {{total}}',
+    noValidPlacements: 'No valid placements',
   },
   sidebar: {
     terrainCard: 'Terrain Card',
@@ -257,6 +258,7 @@ export const en = {
     tapHighlightedDestinationToMove: 'Tap a highlighted destination to move.',
     tapHighlightedSettlementToMove: 'Tap a highlighted settlement to move.',
     tapHighlightedCellToPlace: 'Tap a highlighted cell to place.',
+    leading: 'Leading',
     mobileFloating: {
       draw: 'Draw',
       endTurn: 'End Turn',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -236,6 +236,7 @@ export const zhTW = {
     phaseLabel: '階段',
     placementsProgress: '已放置 {{placed}} / {{total}} 個聚落',
     ofSettlements: '{{placed}} / {{total}}',
+    noValidPlacements: '無可放置位置',
   },
   sidebar: {
     terrainCard: '地形卡',
@@ -255,6 +256,7 @@ export const zhTW = {
     tapHighlightedDestinationToMove: '點擊高亮目的地以移動。',
     tapHighlightedSettlementToMove: '點擊高亮聚落以移動。',
     tapHighlightedCellToPlace: '點擊高亮格子以放置。',
+    leading: '領先',
     mobileFloating: {
       draw: '抽牌',
       endTurn: '結束回合',

--- a/src/test/mobile.test.tsx
+++ b/src/test/mobile.test.tsx
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import React from 'react';
 
 import { useBoardTransform } from '../hooks/useBoardTransform';
@@ -17,6 +17,7 @@ import { BottomDrawer } from '../components/Mobile/BottomDrawer';
 import { GamePhase, BotDifficulty } from '../types';
 import type { Player } from '../types';
 import type { GameAction } from '../types/history';
+import { ObjectiveCard } from '../core/scoring';
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
@@ -37,12 +38,38 @@ function makePlayer(overrides?: Partial<Player>): Player {
 
 /** Build a minimal BottomDrawer props set. */
 function makeDrawerProps(overrides?: Record<string, unknown>) {
+  const players = [
+    makePlayer({ id: 1, name: 'Alice', color: '#ff0000' }),
+    makePlayer({ id: 2, name: 'Bob', color: '#0000ff' }),
+  ];
+
   return {
     isOpen: false,
     onToggle: vi.fn(),
     phase: GamePhase.DrawCard,
-    currentPlayer: makePlayer(),
+    currentPlayer: players[0],
+    players,
     currentTerrainCard: null,
+    objectiveCards: [ObjectiveCard.Hermits, ObjectiveCard.Farmers],
+    liveScores: [
+      {
+        playerId: 1,
+        castle: 3,
+        objectives: [
+          { card: ObjectiveCard.Hermits, score: 5 },
+          { card: ObjectiveCard.Farmers, score: 2 },
+        ],
+      },
+      {
+        playerId: 2,
+        castle: 1,
+        objectives: [
+          { card: ObjectiveCard.Hermits, score: 0 },
+          { card: ObjectiveCard.Farmers, score: 1 },
+        ],
+      },
+    ],
+    maxLiveScore: 10,
     remainingPlacements: 0,
     activeTile: null,
     tileMoveFrom: null,
@@ -216,45 +243,32 @@ describe('BottomDrawer', () => {
     expect(onToggle).toHaveBeenCalledOnce();
   });
 
-  // NOTE: Draw/Undo/EndTurn buttons are in App.tsx mobileFloating section, not in BottomDrawer component
-  it.skip('shows Draw Terrain Card button when phase is DrawCard', () => {
-    const props = makeDrawerProps({ isOpen: true, phase: GamePhase.DrawCard });
+  it('shows objective cards in the expanded drawer', () => {
+    const props = makeDrawerProps({ isOpen: true });
     render(React.createElement(BottomDrawer, props));
-    expect(screen.getByRole('button', { name: /draw terrain card/i })).toBeTruthy();
+
+    expect(screen.getByRole('region', { name: 'Objectives' })).toBeTruthy();
+    expect(screen.getByText('Hermits')).toBeTruthy();
+    expect(screen.getByText('Farmers')).toBeTruthy();
   });
 
-  it.skip('calls onDrawCard when Draw Terrain Card is clicked', () => {
-    const onDrawCard = vi.fn();
-    const props = makeDrawerProps({
-      isOpen: true,
-      phase: GamePhase.DrawCard,
-      onDrawCard,
-    });
+  it('shows live scores with the leading player marked', () => {
+    const props = makeDrawerProps({ isOpen: true, phase: GamePhase.PlaceSettlements });
     render(React.createElement(BottomDrawer, props));
-    fireEvent.click(screen.getByRole('button', { name: /draw terrain card/i }));
-    expect(onDrawCard).toHaveBeenCalledOnce();
+
+    const liveScores = screen.getByRole('region', { name: 'Live Scores' });
+    expect(liveScores).toBeTruthy();
+    expect(within(liveScores).getByText('Alice')).toBeTruthy();
+    expect(within(liveScores).getByText(/10\s+pts/)).toBeTruthy();
+    expect(within(liveScores).getByTitle('Leading')).toBeTruthy();
+    expect(within(liveScores).getByText('🏰 3 | Hermits: 5 | Farmers: 2')).toBeTruthy();
   });
 
-  it.skip('shows End Turn and Undo buttons in EndTurn phase', () => {
-    const props = makeDrawerProps({
-      isOpen: true,
-      phase: GamePhase.EndTurn,
-      canUndo: true,
-    });
+  it('does not show live scores during setup phase', () => {
+    const props = makeDrawerProps({ isOpen: true, phase: GamePhase.Setup });
     render(React.createElement(BottomDrawer, props));
-    expect(screen.getByRole('button', { name: /end turn/i })).toBeTruthy();
-    expect(screen.getByRole('button', { name: /undo/i })).toBeTruthy();
-  });
 
-  it.skip('Undo button is disabled when canUndo is false', () => {
-    const props = makeDrawerProps({
-      isOpen: true,
-      phase: GamePhase.EndTurn,
-      canUndo: false,
-    });
-    render(React.createElement(BottomDrawer, props));
-    const undoBtn = screen.getByRole('button', { name: /undo/i });
-    expect(undoBtn).toBeDisabled();
+    expect(screen.queryByRole('region', { name: 'Live Scores' })).toBeNull();
   });
 
   it('swipe up opens the drawer (calls onToggle)', () => {

--- a/tests/e2e/mobile-drawer.spec.ts
+++ b/tests/e2e/mobile-drawer.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+import { SetupPage } from '../pages/SetupPage';
+import { GamePage } from '../pages/GamePage';
+
+test.beforeEach(async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 });
+  await page.addInitScript(() => {
+    localStorage.setItem('i18nextLng', 'en');
+  });
+});
+
+test('mobile drawer: shows objectives and live scores during a game', async ({ page }) => {
+  const setupPage = new SetupPage(page);
+  const gamePage = new GamePage(page);
+
+  await setupPage.goto(42);
+  await setupPage.startGame();
+  await expect(gamePage.header).toBeVisible();
+
+  const drawer = page.getByRole('region', { name: 'Game controls' });
+  await drawer.getByLabel('Open game panel').click();
+  await expect(drawer).toHaveAttribute('aria-expanded', 'true');
+  await expect(drawer.getByRole('region', { name: 'Objectives' })).toBeVisible();
+  const liveScores = drawer.getByRole('region', { name: 'Live Scores' });
+  await expect(liveScores).toBeVisible();
+  await expect(liveScores.getByText('Player 1')).toBeVisible();
+  await expect(liveScores.getByText('0 pts').first()).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- Add objective cards and live scores to the mobile bottom drawer
- Pass existing App score/objective data into the mobile drawer without changing game rules
- Localize the TurnBanner no-valid-placement label
- Harden Playwright webServer config so local E2E does not accidentally reuse another app on port 5173

## Verification
- npm run lint
- npm run build
- npm test -- --run
- PLAYWRIGHT_BASE_URL=http://127.0.0.1:5179 npx playwright test --project=chromium --retries=0
- node ~/HurricaneCore/eye/dist/cli.js detect-changes --staged --human
- Mobile viewport visual check: /Users/yinghaowang/vscode/developer/workspace/tmp/kingdom-builder-mobile-drawer-r2-expanded.png