### PR TITLE
Add interactive tutorial guidance

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { GameSetup } from './components/Game/GameSetup'
 import { MultiplayerSetup } from './components/Game/MultiplayerSetup'
 import { MainMenu } from './components/Menu/MainMenu'
 import { TutorialOverlay } from './components/Tutorial/TutorialOverlay'
+import { useTutorialStore } from './store/tutorialStore'
 import { TurnBanner } from './components/Game/TurnBanner'
 import { GamePhase } from './types'
 import type { PlayerConfig, GameOptions } from './types'
@@ -294,6 +295,7 @@ function App() {
         () => placeSettlement(coord),
         { type: 'place_settlement', coord }
       )
+      useTutorialStore.getState().advanceTutorialIf('placeSettlement');
       playSound(SoundType.PLACE);
     }
   }
@@ -326,6 +328,7 @@ function App() {
       () => drawTerrainCard(),
       { type: 'draw_terrain_card' }
     );
+    useTutorialStore.getState().advanceTutorialIf('drawCard');
   };
 
   const handleEndTurn = () => {
@@ -333,6 +336,7 @@ function App() {
       () => endTurn(),
       { type: 'end_turn' }
     );
+    useTutorialStore.getState().advanceTutorialIf('endTurn');
   };
 
   const handleUndo = () => {
@@ -581,6 +585,7 @@ function App() {
           {/* HexGrid */}
           <div className="flex-1 relative overflow-hidden">
             {players.length > 0 && (
+              <div className="w-full h-full" data-tutorial-target="hex-grid">
               <HexGrid
                 board={board}
                 validPlacements={
@@ -594,6 +599,7 @@ function App() {
                 onCellSelect={selectCell}
                 onEscape={handleEscape}
               />
+              </div>
             )}
           </div>
 
@@ -611,6 +617,7 @@ function App() {
                 onClick={handleDrawTerrainCard}
                 disabled={!canControlActions}
                 aria-label={t('app.drawTerrainCardAria')}
+                data-tutorial-target="draw-card-button"
                 className="flex-1 flex items-center justify-center gap-1.5 font-bold py-2.5 rounded-xl transition disabled:opacity-50"
                 style={{
                   backgroundColor: 'var(--button-primary-bg)',
@@ -880,6 +887,7 @@ function App() {
               {objectiveCards.length > 0 && (
                 <section
                   aria-label={t('sidebar.objectives')}
+                  data-tutorial-target="objectives-section"
                   className="rounded-xl overflow-hidden"
                   style={{
                     border: '1px solid var(--card-border)',

--- a/src/components/Game/TurnBanner.tsx
+++ b/src/components/Game/TurnBanner.tsx
@@ -115,6 +115,7 @@ export const TurnBanner: React.FC<TurnBannerProps> = ({
             onClick={onDrawCard}
             disabled={!canControlActions}
             aria-label={t('app.drawTerrainCardAria')}
+            data-tutorial-target="draw-card-button"
             className="flex items-center gap-1.5 text-sm font-bold px-3 py-1.5 rounded-lg transition
               bg-white text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed
               focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"

--- a/src/components/Tutorial/TutorialOverlay.test.tsx
+++ b/src/components/Tutorial/TutorialOverlay.test.tsx
@@ -1,0 +1,56 @@
+import { act, render, screen } from '@testing-library/react';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { TutorialOverlay } from './TutorialOverlay';
+import { TUTORIAL_STEPS, useTutorialStore } from '../../store/tutorialStore';
+
+function setTutorialStep(stepId: string): void {
+  const stepIndex = TUTORIAL_STEPS.findIndex((step) => step.id === stepId);
+  expect(stepIndex).toBeGreaterThanOrEqual(0);
+  act(() => {
+    useTutorialStore.setState({ isActive: true, currentStepIndex: stepIndex, hasCompleted: false });
+  });
+}
+
+describe('TutorialOverlay', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+    Element.prototype.scrollIntoView = vi.fn();
+    useTutorialStore.setState({ isActive: false, currentStepIndex: 0, hasCompleted: false });
+  });
+
+  it('renders a spotlight around the current target element', async () => {
+    render(
+      <>
+        <button data-tutorial-target="draw-card-button">Draw Terrain Card</button>
+        <TutorialOverlay />
+      </>
+    );
+
+    const target = screen.getByRole('button', { name: 'Draw Terrain Card' });
+    vi.spyOn(target, 'getBoundingClientRect').mockReturnValue({
+      x: 30,
+      y: 40,
+      top: 40,
+      left: 30,
+      right: 150,
+      bottom: 80,
+      width: 120,
+      height: 40,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    setTutorialStep('terrain-card');
+
+    expect(await screen.findByTestId('tutorial-spotlight')).toBeTruthy();
+    expect(screen.getByText('Perform the highlighted action to continue automatically.')).toBeTruthy();
+  });
+
+  it('falls back to the default step copy when a target is absent', () => {
+    setTutorialStep('welcome');
+    render(<TutorialOverlay />);
+
+    expect(screen.getByRole('dialog', { name: 'Tutorial' })).toBeTruthy();
+    expect(screen.queryByTestId('tutorial-spotlight')).toBeNull();
+  });
+});

--- a/src/components/Tutorial/TutorialOverlay.tsx
+++ b/src/components/Tutorial/TutorialOverlay.tsx
@@ -1,11 +1,32 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 import { useTutorialStore, TUTORIAL_STEPS } from '../../store/tutorialStore';
 import { useTranslation } from 'react-i18next';
+
+interface SpotlightRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+function stepIdToI18nKey(stepId: string): string {
+  return stepId.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
+}
+
+function findTutorialTarget(targetElement?: string): HTMLElement | null {
+  if (!targetElement) return null;
+  return (
+    document.querySelector<HTMLElement>(`[data-tutorial-target="${targetElement}"]`) ??
+    document.getElementById(targetElement) ??
+    document.querySelector<HTMLElement>(targetElement)
+  );
+}
 
 export function TutorialOverlay() {
   const { t } = useTranslation();
   const { isActive, currentStepIndex, nextStep, prevStep, completeTutorial, dismissTutorial } =
     useTutorialStore();
+  const [spotlightRect, setSpotlightRect] = useState<SpotlightRect | null>(null);
 
   const step = TUTORIAL_STEPS[currentStepIndex];
   const isLastStep = currentStepIndex === TUTORIAL_STEPS.length - 1;
@@ -30,25 +51,76 @@ export function TutorialOverlay() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [isActive, handleKeyDown]);
 
+  useEffect(() => {
+    if (!isActive || !step?.targetElement) {
+      return;
+    }
+
+    let frameId = 0;
+
+    const updateSpotlight = () => {
+      const target = findTutorialTarget(step.targetElement);
+      if (!target) {
+        setSpotlightRect(null);
+        return;
+      }
+
+      target.scrollIntoView({ block: 'center', inline: 'center', behavior: 'smooth' });
+      frameId = window.requestAnimationFrame(() => {
+        const rect = target.getBoundingClientRect();
+        if (rect.width === 0 || rect.height === 0) {
+          setSpotlightRect(null);
+          return;
+        }
+
+        const padding = 8;
+        setSpotlightRect({
+          top: Math.max(8, rect.top - padding),
+          left: Math.max(8, rect.left - padding),
+          width: Math.min(window.innerWidth - Math.max(8, rect.left - padding) - 8, rect.width + padding * 2),
+          height: Math.min(window.innerHeight - Math.max(8, rect.top - padding) - 8, rect.height + padding * 2),
+        });
+      });
+    };
+
+    frameId = window.requestAnimationFrame(updateSpotlight);
+    window.addEventListener('resize', updateSpotlight);
+    window.addEventListener('scroll', updateSpotlight, true);
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      window.removeEventListener('resize', updateSpotlight);
+      window.removeEventListener('scroll', updateSpotlight, true);
+    };
+  }, [isActive, step]);
+
   if (!isActive || !step) return null;
 
   const progress = ((currentStepIndex + 1) / TUTORIAL_STEPS.length) * 100;
-  const translatedTitle = t(`tutorial.steps.${step.id}.title`, { defaultValue: step.title });
-  const translatedDescription = t(`tutorial.steps.${step.id}.description`, { defaultValue: step.description });
+  const stepI18nKey = stepIdToI18nKey(step.id);
+  const translatedTitle = t(`tutorial.steps.${stepI18nKey}.title`, { defaultValue: step.title });
+  const translatedDescription = t(`tutorial.steps.${stepI18nKey}.description`, { defaultValue: step.description });
+  const shouldShowActionHint = step.advanceOn !== undefined && step.advanceOn !== 'none';
 
   return (
-    /* Semi-transparent backdrop */
     <div
       role="dialog"
       aria-modal="true"
       aria-label={t('tutorial.dialogLabel')}
-      className="fixed inset-0 z-50 flex items-center justify-center"
-      style={{ backgroundColor: 'rgba(0, 0, 0, 0.65)' }}
-      onClick={dismissTutorial}
+      className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
     >
+      <div className="absolute inset-0 bg-black/65 pointer-events-none" aria-hidden="true" />
+      {step.targetElement && spotlightRect && (
+        <div
+          data-testid="tutorial-spotlight"
+          aria-hidden="true"
+          className="fixed rounded-xl border-4 border-yellow-300 shadow-[0_0_0_9999px_rgba(0,0,0,0.5),0_0_24px_rgba(250,204,21,0.9)] transition-all duration-200"
+          style={spotlightRect}
+        />
+      )}
+
       {/* Tooltip card – stop propagation so clicks inside don't close */}
       <div
-        className="relative bg-white rounded-2xl shadow-2xl p-6 w-full max-w-md mx-4 flex flex-col gap-4"
+        className="relative bg-white rounded-2xl shadow-2xl p-6 w-full max-w-md mx-4 flex flex-col gap-4 pointer-events-auto"
         onClick={(e) => e.stopPropagation()}
         role="document"
       >
@@ -73,6 +145,12 @@ export function TutorialOverlay() {
 
         {/* Description */}
         <p className="text-gray-600 leading-relaxed">{translatedDescription}</p>
+
+        {shouldShowActionHint && (
+          <p className="text-sm font-semibold text-blue-700 bg-blue-50 border border-blue-100 rounded-lg px-3 py-2">
+            {t('tutorial.performHighlightedAction')}
+          </p>
+        )}
 
         {/* Progress bar */}
         <div className="w-full bg-gray-200 rounded-full h-1.5" aria-hidden="true">

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -351,6 +351,7 @@ export const en = {
     finish: 'Finish 🎉',
     next: 'Next →',
     keyboardHint: 'Press left/right arrow keys to navigate · Esc to close',
+    performHighlightedAction: 'Perform the highlighted action to continue automatically.',
     steps: {
       welcome: {
         title: 'Welcome to Kingdom Builder!',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -349,6 +349,7 @@ export const zhTW = {
     finish: '完成 🎉',
     next: '下一步 →',
     keyboardHint: '按左右方向鍵切換 · Esc 關閉',
+    performHighlightedAction: '執行高亮操作即可自動前進。',
     steps: {
       welcome: {
         title: '歡迎來到王國建造者！',

--- a/src/store/tutorialStore.ts
+++ b/src/store/tutorialStore.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 import type { TutorialStep } from '../types';
 
+export type TutorialAdvanceTrigger = Exclude<NonNullable<TutorialStep['advanceOn']>, 'none'>;
+
 // ────────────────────────────────────────────────────
 // Tutorial step definitions
 // ────────────────────────────────────────────────────
@@ -37,7 +39,7 @@ export const TUTORIAL_STEPS: TutorialStep[] = [
       'At the start of each turn you draw a Terrain Card. The card tells you which terrain type you must place your 3 settlements on this turn. You cannot choose — the card decides! Click "Draw Terrain Card" to start your turn.',
     icon: '🃏',
     targetElement: 'draw-card-button',
-    advanceOn: 'none',
+    advanceOn: 'drawCard',
   },
   {
     id: 'placement-rules',
@@ -45,7 +47,8 @@ export const TUTORIAL_STEPS: TutorialStep[] = [
     description:
       "You must place exactly 3 settlements on the terrain shown on your card. If you already have a settlement adjacent to valid terrain, you MUST place next to your existing settlement (adjacency rule). The highlighted cells show where you can legally place.",
     icon: '📏',
-    advanceOn: 'none',
+    targetElement: 'hex-grid',
+    advanceOn: 'placeSettlement',
   },
   {
     id: 'location-tile-gain',
@@ -70,7 +73,7 @@ export const TUTORIAL_STEPS: TutorialStep[] = [
     description:
       '1️⃣ Draw a Terrain Card → 2️⃣ Place 3 settlements on matching terrain (following adjacency rules) → 3️⃣ End your turn. Optionally use a Location Tile ability before ending. Repeat until all settlements are placed!',
     icon: '🔄',
-    advanceOn: 'none',
+    advanceOn: 'endTurn',
   },
   {
     id: 'scoring',
@@ -109,6 +112,7 @@ export interface TutorialState {
   nextStep: () => void;
   prevStep: () => void;
   goToStep: (index: number) => void;
+  advanceTutorialIf: (trigger: TutorialAdvanceTrigger) => void;
   completeTutorial: () => void;
   dismissTutorial: () => void;
 }
@@ -146,6 +150,19 @@ export const useTutorialStore = create<TutorialState>((set) => ({
 
   goToStep: (index: number) =>
     set({ currentStepIndex: Math.max(0, Math.min(index, TUTORIAL_STEPS.length - 1)) }),
+
+  advanceTutorialIf: (trigger: TutorialAdvanceTrigger) =>
+    set((state) => {
+      if (!state.isActive) return state;
+      const step = TUTORIAL_STEPS[state.currentStepIndex];
+      if (step?.advanceOn !== trigger) return state;
+
+      const next = state.currentStepIndex + 1;
+      if (next >= TUTORIAL_STEPS.length) {
+        return markCompleted();
+      }
+      return { currentStepIndex: next };
+    }),
 
   completeTutorial: () => set(markCompleted),
 

--- a/src/test/tutorialStore.test.ts
+++ b/src/test/tutorialStore.test.ts
@@ -116,6 +116,27 @@ describe('tutorialStore', () => {
     expect(localStorageMock.getItem('tutorialCompleted')).toBe('true');
   });
 
+  it('advanceTutorialIf advances only when the current step trigger matches', () => {
+    useTutorialStore.getState().startTutorial();
+    const terrainCardStep = TUTORIAL_STEPS.findIndex((step) => step.id === 'terrain-card');
+    useTutorialStore.getState().goToStep(terrainCardStep);
+
+    useTutorialStore.getState().advanceTutorialIf('placeSettlement');
+    expect(useTutorialStore.getState().currentStepIndex).toBe(terrainCardStep);
+
+    useTutorialStore.getState().advanceTutorialIf('drawCard');
+    expect(useTutorialStore.getState().currentStepIndex).toBe(terrainCardStep + 1);
+  });
+
+  it('advanceTutorialIf ignores triggers while inactive', () => {
+    const terrainCardStep = TUTORIAL_STEPS.findIndex((step) => step.id === 'terrain-card');
+    useTutorialStore.getState().goToStep(terrainCardStep);
+
+    useTutorialStore.getState().advanceTutorialIf('drawCard');
+
+    expect(useTutorialStore.getState().currentStepIndex).toBe(terrainCardStep);
+  });
+
   it('TUTORIAL_STEPS has at least one step with required fields', () => {
     expect(TUTORIAL_STEPS.length).toBeGreaterThan(0);
     for (const step of TUTORIAL_STEPS) {
@@ -123,5 +144,11 @@ describe('tutorialStore', () => {
       expect(step.title).toBeTruthy();
       expect(step.description).toBeTruthy();
     }
+  });
+
+  it('defines interactive tutorial triggers for core game actions', () => {
+    expect(TUTORIAL_STEPS.find((step) => step.id === 'terrain-card')?.advanceOn).toBe('drawCard');
+    expect(TUTORIAL_STEPS.find((step) => step.id === 'placement-rules')?.advanceOn).toBe('placeSettlement');
+    expect(TUTORIAL_STEPS.find((step) => step.id === 'turn-flow')?.advanceOn).toBe('endTurn');
   });
 });

--- a/tests/e2e/tutorial.spec.ts
+++ b/tests/e2e/tutorial.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { SetupPage } from '../pages/SetupPage';
+import { GamePage } from '../pages/GamePage';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('i18nextLng', 'en');
+  });
+});
+
+test('tutorial: highlighted draw card action advances the tutorial', async ({ page }) => {
+  const setupPage = new SetupPage(page);
+  const gamePage = new GamePage(page);
+
+  await setupPage.goto(42);
+  await setupPage.setPlayerType(1, 'human');
+  await setupPage.startGame();
+  await expect(gamePage.header).toBeVisible();
+
+  await page.evaluate(async () => {
+    const tutorial = await import('/src/store/tutorialStore.ts');
+    const stepIndex = tutorial.TUTORIAL_STEPS.findIndex((step) => step.id === 'terrain-card');
+    tutorial.useTutorialStore.getState().startTutorial();
+    tutorial.useTutorialStore.getState().goToStep(stepIndex);
+  });
+
+  const dialog = page.getByRole('dialog', { name: 'Tutorial' });
+  await expect(dialog).toContainText('Terrain Cards');
+  await expect(page.getByTestId('tutorial-spotlight')).toBeVisible();
+
+  await page
+    .getByRole('status', { name: /Player 1's turn/ })
+    .getByRole('button', { name: 'Draw terrain card to start your turn' })
+    .click();
+
+  await expect(dialog).toContainText('Placement Rules');
+  await expect(gamePage.liveRegion).toContainText('PlaceSettlements');
+});


### PR DESCRIPTION
## Summary
- add tutorial auto-advance triggers for draw card, settlement placement, and end turn
- add spotlight targeting for tutorial steps while keeping highlighted game actions clickable
- cover tutorial store behavior, overlay spotlight rendering, and draw-card auto-advance E2E

## Verification
- npm run lint
- npm run build
- npm test -- --run
- PLAYWRIGHT_BASE_URL=http://127.0.0.1:5181 npx playwright test --project=chromium --retries=0
- node ~/HurricaneCore/eye/dist/cli.js detect-changes --staged --human
- CEO Playwright screenshot: /Users/yinghaowang/vscode/developer/workspace/tmp/kingdom-builder-tutorial-spotlight-r3.png

## Security
- No auth, websocket, scoring, persistence key, external endpoint, or secret handling changes. Security double review not triggered.