### PR TITLE
Add objective card rule descriptions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { MainMenu } from './components/Menu/MainMenu'
 import { TutorialOverlay } from './components/Tutorial/TutorialOverlay'
 import { useTutorialStore } from './store/tutorialStore'
 import { TurnBanner } from './components/Game/TurnBanner'
+import { ObjectiveCardBadge } from './components/Game/ObjectiveCardBadge'
 import { GamePhase } from './types'
 import type { PlayerConfig, GameOptions } from './types'
 import { Location } from './core/terrain'
@@ -308,6 +309,8 @@ function App() {
       score: board ? scoreObjectiveCard(card, board, p.id) : 0,
     })),
   }))
+  const currentPlayerObjectiveScores =
+    liveScores.find(playerScore => playerScore.playerId === currentPlayer?.id)?.objectives ?? []
 
   const handleEscape = () => {
     selectCell(null);
@@ -904,21 +907,13 @@ function App() {
                   >
                     {t('sidebar.objectives')}
                   </div>
-                  <div
-                    className="p-3 flex flex-wrap gap-2"
-                    style={{ backgroundColor: 'var(--color-surface)' }}
-                  >
+                  <div className="p-3 grid gap-2" style={{ backgroundColor: 'var(--color-surface)' }}>
                     {objectiveCards.map(card => (
-                      <span
+                      <ObjectiveCardBadge
                         key={card}
-                        className="px-3 py-1.5 text-xs font-semibold rounded-lg"
-                        style={{
-                          backgroundColor: 'var(--color-player-blue)',
-                          color: 'var(--color-warm-cream-50)',
-                        }}
-                      >
-                        {tObjective(t, card)}
-                      </span>
+                        card={card}
+                        score={currentPlayerObjectiveScores.find(objective => objective.card === card)?.score}
+                      />
                     ))}
                   </div>
                 </section>

--- a/src/components/Game/ObjectiveCardBadge.test.tsx
+++ b/src/components/Game/ObjectiveCardBadge.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ObjectiveCard } from '../../core/scoring';
+import { ALL_OBJECTIVE_CARDS } from '../../core/scoring';
+import { ObjectiveCardBadge } from './ObjectiveCardBadge';
+import { en } from '../../i18n/locales/en';
+import { zhTW } from '../../i18n/locales/zh-TW';
+
+describe('ObjectiveCardBadge', () => {
+  it('renders the objective name, rule description, and score preview', () => {
+    render(<ObjectiveCardBadge card={ObjectiveCard.Hermits} score={6} />);
+
+    expect(screen.getByTestId('objective-name')).toHaveTextContent('Hermits');
+    expect(screen.getByTestId('objective-description')).toHaveTextContent('isolated settlement');
+    expect(screen.getByTestId('objective-score-preview')).toHaveTextContent('6 pts');
+  });
+
+  it('has rule descriptions for every objective in both supported languages', () => {
+    for (const card of ALL_OBJECTIVE_CARDS) {
+      expect(en.objectiveDescription[card]).toBeTruthy();
+      expect(zhTW.objectiveDescription[card]).toBeTruthy();
+    }
+  });
+});

--- a/src/components/Game/ObjectiveCardBadge.tsx
+++ b/src/components/Game/ObjectiveCardBadge.tsx
@@ -1,0 +1,53 @@
+import type { ObjectiveCard } from '../../core/scoring';
+import { tObjective, tObjectiveDescription } from '../../i18n/formatters';
+import { useTranslation } from 'react-i18next';
+
+interface ObjectiveCardBadgeProps {
+  card: ObjectiveCard;
+  score?: number;
+  className?: string;
+}
+
+export function ObjectiveCardBadge({ card, score, className = '' }: ObjectiveCardBadgeProps) {
+  const { t } = useTranslation();
+  const title = tObjective(t, card);
+  const description = tObjectiveDescription(t, card);
+
+  return (
+    <article
+      data-testid="objective-card"
+      aria-label={`${title}. ${description}`}
+      className={`rounded-lg px-3 py-2 text-left ${className}`}
+      style={{
+        backgroundColor: 'oklch(0.97 0.02 255)',
+        border: '1px solid var(--color-player-blue)',
+        color: 'var(--color-stone-800)',
+      }}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <h3 data-testid="objective-name" className="text-sm font-bold leading-tight">
+          {title}
+        </h3>
+        {score !== undefined && (
+          <span
+            data-testid="objective-score-preview"
+            className="shrink-0 rounded-full px-2 py-0.5 text-[11px] font-bold leading-none"
+            style={{
+              backgroundColor: 'var(--color-player-blue)',
+              color: 'var(--color-warm-cream-50)',
+            }}
+          >
+            {t('objectiveCard.currentScore', { score })}
+          </span>
+        )}
+      </div>
+      <p
+        data-testid="objective-description"
+        className="mt-1 text-xs leading-snug"
+        style={{ color: 'var(--color-stone-600)' }}
+      >
+        {description}
+      </p>
+    </article>
+  );
+}

--- a/src/components/Mobile/BottomDrawer.tsx
+++ b/src/components/Mobile/BottomDrawer.tsx
@@ -6,6 +6,7 @@ import { GameAction } from '../../types/history';
 import type { ObjectiveCard } from '../../core/scoring';
 import { useTranslation } from 'react-i18next';
 import { tLocation, tObjective, tPhase, tTerrain } from '../../i18n/formatters';
+import { ObjectiveCardBadge } from '../Game/ObjectiveCardBadge';
 import {
   CastleIcon,
   FarmIcon,
@@ -95,6 +96,8 @@ export const BottomDrawer: React.FC<BottomDrawerProps> = ({
 }) => {
   const { t } = useTranslation();
   const dragStartY = useRef<number | null>(null);
+  const currentPlayerObjectiveScores =
+    liveScores.find(playerScore => playerScore.playerId === currentPlayer?.id)?.objectives ?? [];
 
   const handleDragHandleTouchStart = useCallback((e: React.TouchEvent) => {
     dragStartY.current = e.touches[0].clientY;
@@ -356,18 +359,13 @@ export const BottomDrawer: React.FC<BottomDrawerProps> = ({
               >
                 {t('sidebar.objectives')}
               </div>
-              <div className="p-3 flex flex-wrap gap-2" style={{ backgroundColor: 'var(--color-surface)' }}>
+              <div className="p-3 grid gap-2" style={{ backgroundColor: 'var(--color-surface)' }}>
                 {objectiveCards.map(card => (
-                  <span
+                  <ObjectiveCardBadge
                     key={card}
-                    className="px-3 py-1.5 text-xs font-semibold rounded-lg"
-                    style={{
-                      backgroundColor: 'var(--color-player-blue)',
-                      color: 'var(--color-warm-cream-50)',
-                    }}
-                  >
-                    {tObjective(t, card)}
-                  </span>
+                    card={card}
+                    score={currentPlayerObjectiveScores.find(objective => objective.card === card)?.score}
+                  />
                 ))}
               </div>
             </section>

--- a/src/i18n/formatters.ts
+++ b/src/i18n/formatters.ts
@@ -18,3 +18,7 @@ export function tLocation(t: TFunction, location: Location): string {
 export function tObjective(t: TFunction, objective: ObjectiveCard): string {
   return t(`objective.${objective}`);
 }
+
+export function tObjectiveDescription(t: TFunction, objective: ObjectiveCard): string {
+  return t(`objectiveDescription.${objective}`);
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -46,6 +46,21 @@ export const en = {
     Lords: 'Lords',
     Shepherds: 'Shepherds',
   },
+  objectiveDescription: {
+    Fisherman: 'Each connected settlement group adjacent to water scores 2 points.',
+    Miners: 'Each settlement adjacent to a mountain scores 2 points.',
+    Knights: 'Your longest horizontal chain scores 1 point per settlement in that chain.',
+    Farmers: 'Your fullest board quadrant scores 1 point per settlement in that quadrant.',
+    Merchants: 'Score 1 point for each different terrain type occupied by your settlements.',
+    Rangers: 'Your longest vertical chain scores 1 point per settlement in that chain.',
+    Hermits: 'Each isolated settlement with no adjacent friendly settlement scores 3 points.',
+    Citizens: 'Each settlement adjacent to a castle scores 3 points.',
+    Lords: 'Each quadrant containing at least one of your settlements scores 3 points.',
+    Shepherds: 'Each connected settlement group scores 3 points.',
+  },
+  objectiveCard: {
+    currentScore: '{{score}} pts',
+  },
   menu: {
     subtitle: 'A Strategic Kingdom Building Game',
     singlePlayer: 'Single Player',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -46,6 +46,21 @@ export const zhTW = {
     Lords: '領主',
     Shepherds: '牧羊人',
   },
+  objectiveDescription: {
+    Fisherman: '每個相鄰水域的相連聚落群得 2 分。',
+    Miners: '每個相鄰山脈的聚落得 2 分。',
+    Knights: '你最長的水平連續聚落鏈，每個聚落得 1 分。',
+    Farmers: '你聚落最多的棋盤象限，該象限每個聚落得 1 分。',
+    Merchants: '你的聚落占據的每種不同地形各得 1 分。',
+    Rangers: '你最長的垂直連續聚落鏈，每個聚落得 1 分。',
+    Hermits: '每個沒有相鄰友方聚落的孤立聚落得 3 分。',
+    Citizens: '每個相鄰城堡的聚落得 3 分。',
+    Lords: '每個至少有一個己方聚落的象限得 3 分。',
+    Shepherds: '每個相連聚落群得 3 分。',
+  },
+  objectiveCard: {
+    currentScore: '{{score}} 分',
+  },
   menu: {
     subtitle: '策略性王國建造遊戲',
     singlePlayer: '單人模式',

--- a/tests/e2e/objectives.spec.ts
+++ b/tests/e2e/objectives.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { SetupPage } from '../pages/SetupPage';
+import { GamePage } from '../pages/GamePage';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('i18nextLng', 'en');
+  });
+});
+
+test('desktop objectives: cards explain how scoring works', async ({ page }) => {
+  const setupPage = new SetupPage(page);
+  const gamePage = new GamePage(page);
+
+  await setupPage.goto(42);
+  await setupPage.startGame();
+  await expect(gamePage.header).toBeVisible();
+
+  const objectives = page.getByRole('region', { name: 'Objectives' }).first();
+  await expect(objectives).toBeVisible();
+  await expect(objectives.getByTestId('objective-card')).toHaveCount(3);
+  await expect(objectives).toContainText('Citizens');
+  await expect(objectives).toContainText('Each settlement adjacent to a castle scores 3 points.');
+  await expect(objectives).toContainText('Hermits');
+  await expect(objectives).toContainText('Each isolated settlement with no adjacent friendly settlement scores 3 points.');
+});
+
+test('mobile objectives: drawer cards include rule descriptions', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 });
+  const setupPage = new SetupPage(page);
+  const gamePage = new GamePage(page);
+
+  await setupPage.goto(42);
+  await setupPage.startGame();
+  await expect(gamePage.header).toBeVisible();
+
+  const drawer = page.getByRole('region', { name: 'Game controls' });
+  await drawer.getByLabel('Open game panel').click();
+
+  const objectives = drawer.getByRole('region', { name: 'Objectives' });
+  await expect(objectives).toBeVisible();
+  await expect(objectives.getByTestId('objective-card')).toHaveCount(3);
+  await expect(objectives).toContainText('Shepherds');
+  await expect(objectives).toContainText('Each connected settlement group scores 3 points.');
+});


### PR DESCRIPTION
## Summary
- show every active objective as a rule card instead of a name-only pill
- add EN and zh-TW scoring descriptions for all 10 objective cards
- include current-player objective score previews in desktop sidebar and mobile drawer
- add unit and Playwright coverage for objective rule visibility

## Verification
- npm run lint
- npm run build
- npm test -- --run
- PLAYWRIGHT_BASE_URL=http://127.0.0.1:5183 npx playwright test --project=chromium --retries=0
- node ~/HurricaneCore/eye/dist/cli.js detect-changes --staged --human
- CEO Playwright screenshot: /Users/yinghaowang/vscode/developer/workspace/tmp/kingdom-builder-objective-rules-desktop.png

## Security
- Pure UI/i18n display change. No auth, websocket, scoring logic, persistence key, external endpoint, or secret handling changes. Security double review not triggered.