### PR TITLE
Add location tile ability descriptions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { TutorialOverlay } from './components/Tutorial/TutorialOverlay'
 import { useTutorialStore } from './store/tutorialStore'
 import { TurnBanner } from './components/Game/TurnBanner'
 import { ObjectiveCardBadge } from './components/Game/ObjectiveCardBadge'
+import { LocationTileCard, LocationTileIcon } from './components/Game/LocationTileCard'
 import { GamePhase } from './types'
 import type { PlayerConfig, GameOptions } from './types'
 import { Location } from './core/terrain'
@@ -22,7 +23,7 @@ import { useMultiplayerStore } from './store/multiplayerStore'
 import { extractSerializableState } from './multiplayer/stateSerializer'
 import type { MultiplayerAction } from './multiplayer/types'
 import { useTranslation } from 'react-i18next'
-import { tLocation, tObjective, tPhase, tTerrain } from './i18n/formatters'
+import { tObjective, tPhase, tTerrain } from './i18n/formatters'
 import { LeaderboardModal } from './components/Game/LeaderboardModal'
 import { useLeaderboardStore } from './store/leaderboardStore'
 import { ReplayModal } from './components/Game/ReplayModal'
@@ -30,15 +31,6 @@ import { AchievementPanel } from './components/Game/AchievementPanel'
 import { AchievementToast } from './components/Game/AchievementToast'
 import { useAchievementStore, getUnlockedCount } from './store/achievementStore'
 import {
-  CastleIcon,
-  FarmIcon,
-  HarborIcon,
-  OasisIcon,
-  TowerIcon,
-  PaddockIcon,
-  BarnIcon,
-  OracleIcon,
-  TavernIcon,
   MutedIcon,
   UnmutedIcon,
   BotIcon,
@@ -51,19 +43,6 @@ import {
   UndoIcon,
   AchievementIcon,
 } from './components/icons'
-import type { ComponentType, SVGProps } from 'react'
-
-const LOCATION_ICON: Record<Location, ComponentType<{ size?: number } & SVGProps<SVGSVGElement>>> = {
-  [Location.Castle]: CastleIcon,
-  [Location.Farm]: FarmIcon,
-  [Location.Harbor]: HarborIcon,
-  [Location.Oasis]: OasisIcon,
-  [Location.Tower]: TowerIcon,
-  [Location.Paddock]: PaddockIcon,
-  [Location.Barn]: BarnIcon,
-  [Location.Oracle]: OracleIcon,
-  [Location.Tavern]: TavernIcon,
-}
 
 const STATE_BROADCAST_DEBOUNCE_MS = 50;
 
@@ -819,49 +798,21 @@ function App() {
                     {currentPlayer.tiles.length === 0 ? (
                       <p className="text-xs text-center py-2" style={{ color: 'var(--color-stone-400)' }}>—</p>
                     ) : (
-                      <div className="flex flex-wrap gap-2">
+                      <div className="grid gap-2">
                         {currentPlayer.tiles.map((tile, idx) => {
-                          const Ic = LOCATION_ICON[tile.location]
                           const isActive = activeTile === tile.location
                           const canUse = !tile.usedThisTurn &&
                             (phase === GamePhase.PlaceSettlements || phase === GamePhase.EndTurn)
                           return (
-                            <div
+                            <LocationTileCard
                               key={`${tile.location}-${idx}`}
-                              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sm transition"
-                              style={{
-                                border: `2px solid ${isActive ? 'var(--color-warning)' : tile.usedThisTurn ? 'var(--card-border)' : 'var(--color-ink-green-300)'}`,
-                                backgroundColor: tile.usedThisTurn
-                                  ? 'var(--color-warm-cream-100)'
-                                  : isActive
-                                    ? 'oklch(0.97 0.03 70)'
-                                    : 'var(--color-ink-green-50)',
-                                opacity: tile.usedThisTurn ? 0.55 : 1,
-                              }}
-                            >
-                              <Ic size={16} />
-                              <span style={{ color: 'var(--color-text)' }}>{tLocation(t, tile.location)}</span>
-                              {canUse && (
-                                <button
-                                  className="ml-1 text-xs font-bold px-1.5 py-0.5 rounded transition"
-                                  disabled={!canControlActions}
-                                  style={{
-                                    backgroundColor: isActive ? 'var(--color-warning)' : 'var(--color-success)',
-                                    color: 'var(--button-text)',
-                                  }}
-                                  onClick={() =>
-                                    isActive ? handleCancelTile() : handleActivateTile(tile.location)
-                                  }
-                                >
-                                  {isActive ? t('app.cancel') : t('app.use')}
-                                </button>
-                              )}
-                              {tile.usedThisTurn && (
-                                <span className="ml-1 text-xs italic" style={{ color: 'var(--color-stone-400)' }}>
-                                  {t('app.used')}
-                                </span>
-                              )}
-                            </div>
+                              tile={tile}
+                              isActive={isActive}
+                              canUse={canUse}
+                              canControlActions={canControlActions}
+                              onUse={() => handleActivateTile(tile.location)}
+                              onCancel={handleCancelTile}
+                            />
                           )
                         })}
                       </div>
@@ -1084,10 +1035,14 @@ function App() {
                             />
                           </div>
                           {/* Tile icons */}
-                          {player.tiles.map((tile, tileIdx) => {
-                            const TileIc = LOCATION_ICON[tile.location]
-                            return <TileIc key={`${tile.location}-${tileIdx}`} size={12} style={{ color: 'var(--color-stone-500)' }} />
-                          })}
+                          {player.tiles.map((tile, tileIdx) => (
+                            <LocationTileIcon
+                              key={`${tile.location}-${tileIdx}`}
+                              location={tile.location}
+                              size={12}
+                              style={{ color: 'var(--color-stone-500)' }}
+                            />
+                          ))}
                         </div>
                       </div>
                     </li>

--- a/src/components/Game/LocationTileCard.test.tsx
+++ b/src/components/Game/LocationTileCard.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Location } from '../../core/terrain';
+import { LocationTileCard } from './LocationTileCard';
+import { en } from '../../i18n/locales/en';
+import { zhTW } from '../../i18n/locales/zh-TW';
+
+const tile = { location: Location.Farm, usedThisTurn: false };
+
+const playableLocations: Array<keyof typeof en.locationDescription> = [
+  Location.Farm,
+  Location.Harbor,
+  Location.Oasis,
+  Location.Tower,
+  Location.Paddock,
+  Location.Barn,
+  Location.Oracle,
+  Location.Tavern,
+];
+
+describe('LocationTileCard', () => {
+  it('renders the tile name, ability description, and use action', () => {
+    render(
+      <LocationTileCard
+        tile={tile}
+        isActive={false}
+        canUse
+        onUse={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('location-tile-name')).toHaveTextContent('Farm');
+    expect(screen.getByTestId('location-tile-description')).toHaveTextContent('Grass cell');
+    expect(screen.getByRole('button', { name: 'Use' })).toBeEnabled();
+  });
+
+  it('shows the used state without an action button', () => {
+    render(
+      <LocationTileCard
+        tile={{ location: Location.Paddock, usedThisTurn: true }}
+        isActive={false}
+        canUse={false}
+        onUse={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Used')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Use' })).toBeNull();
+  });
+
+  it('has descriptions for every playable location tile in both supported languages', () => {
+    for (const location of playableLocations) {
+      expect(en.locationDescription[location]).toBeTruthy();
+      expect(zhTW.locationDescription[location]).toBeTruthy();
+    }
+  });
+});

--- a/src/components/Game/LocationTileCard.tsx
+++ b/src/components/Game/LocationTileCard.tsx
@@ -1,0 +1,112 @@
+import type { LocationTile } from '../../types';
+import { Location } from '../../core/terrain';
+import { tLocation, tLocationDescription } from '../../i18n/formatters';
+import { useTranslation } from 'react-i18next';
+import {
+  BarnIcon,
+  FarmIcon,
+  HarborIcon,
+  OasisIcon,
+  OracleIcon,
+  PaddockIcon,
+  TavernIcon,
+  TowerIcon,
+} from '../icons';
+import type { ComponentType, SVGProps } from 'react';
+
+const LOCATION_TILE_ICON: Record<Location, ComponentType<{ size?: number } & SVGProps<SVGSVGElement>>> = {
+  [Location.Castle]: TowerIcon,
+  [Location.Farm]: FarmIcon,
+  [Location.Harbor]: HarborIcon,
+  [Location.Oasis]: OasisIcon,
+  [Location.Tower]: TowerIcon,
+  [Location.Paddock]: PaddockIcon,
+  [Location.Barn]: BarnIcon,
+  [Location.Oracle]: OracleIcon,
+  [Location.Tavern]: TavernIcon,
+};
+
+interface LocationTileIconProps extends SVGProps<SVGSVGElement> {
+  location: Location;
+  size?: number;
+}
+
+export function LocationTileIcon({ location, size = 16, ...props }: LocationTileIconProps) {
+  const Icon = LOCATION_TILE_ICON[location];
+  return <Icon size={size} {...props} />;
+}
+
+interface LocationTileCardProps {
+  tile: LocationTile;
+  isActive: boolean;
+  canUse: boolean;
+  canControlActions?: boolean;
+  onUse: () => void;
+  onCancel: () => void;
+  compact?: boolean;
+}
+
+export function LocationTileCard({
+  tile,
+  isActive,
+  canUse,
+  canControlActions = true,
+  onUse,
+  onCancel,
+  compact = false,
+}: LocationTileCardProps) {
+  const { t } = useTranslation();
+  const title = tLocation(t, tile.location);
+  const description = tLocationDescription(t, tile.location);
+
+  return (
+    <article
+      data-testid="location-tile-card"
+      aria-label={`${title}. ${description}`}
+      className="rounded-lg px-3 py-2 text-sm transition"
+      style={{
+        border: `2px solid ${isActive ? 'var(--color-warning)' : tile.usedThisTurn ? 'var(--card-border)' : 'var(--color-ink-green-300)'}`,
+        backgroundColor: tile.usedThisTurn
+          ? 'var(--color-warm-cream-100)'
+          : isActive
+            ? 'oklch(0.97 0.03 70)'
+            : 'var(--color-ink-green-50)',
+        opacity: tile.usedThisTurn ? 0.62 : 1,
+      }}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <LocationTileIcon location={tile.location} size={16} />
+          <h3 data-testid="location-tile-name" className="font-semibold leading-tight" style={{ color: 'var(--color-text)' }}>
+            {title}
+          </h3>
+        </div>
+        {canUse && (
+          <button
+            className="shrink-0 text-xs font-bold px-1.5 py-0.5 rounded transition"
+            disabled={!canControlActions}
+            style={{
+              backgroundColor: isActive ? 'var(--color-warning)' : 'var(--color-success)',
+              color: 'var(--button-text)',
+            }}
+            onClick={isActive ? onCancel : onUse}
+          >
+            {isActive ? t('app.cancel') : t('app.use')}
+          </button>
+        )}
+        {tile.usedThisTurn && (
+          <span className="shrink-0 text-xs italic" style={{ color: 'var(--color-stone-400)' }}>
+            {t('app.used')}
+          </span>
+        )}
+      </div>
+      <p
+        data-testid="location-tile-description"
+        className={compact ? 'mt-1 text-xs leading-snug' : 'mt-1.5 text-xs leading-snug'}
+        style={{ color: 'var(--color-stone-600)' }}
+      >
+        {description}
+      </p>
+    </article>
+  );
+}

--- a/src/components/Mobile/BottomDrawer.tsx
+++ b/src/components/Mobile/BottomDrawer.tsx
@@ -5,32 +5,9 @@ import { Player, LocationTile } from '../../types';
 import { GameAction } from '../../types/history';
 import type { ObjectiveCard } from '../../core/scoring';
 import { useTranslation } from 'react-i18next';
-import { tLocation, tObjective, tPhase, tTerrain } from '../../i18n/formatters';
+import { tObjective, tPhase, tTerrain } from '../../i18n/formatters';
 import { ObjectiveCardBadge } from '../Game/ObjectiveCardBadge';
-import {
-  CastleIcon,
-  FarmIcon,
-  HarborIcon,
-  OasisIcon,
-  TowerIcon,
-  PaddockIcon,
-  BarnIcon,
-  OracleIcon,
-  TavernIcon,
-} from '../icons';
-import type { ComponentType, SVGProps } from 'react';
-
-const LOCATION_ICON: Record<Location, ComponentType<{ size?: number } & SVGProps<SVGSVGElement>>> = {
-  [Location.Castle]:  CastleIcon,
-  [Location.Farm]:    FarmIcon,
-  [Location.Harbor]:  HarborIcon,
-  [Location.Oasis]:   OasisIcon,
-  [Location.Tower]:   TowerIcon,
-  [Location.Paddock]: PaddockIcon,
-  [Location.Barn]:    BarnIcon,
-  [Location.Oracle]:  OracleIcon,
-  [Location.Tavern]:  TavernIcon,
-};
+import { LocationTileCard } from '../Game/LocationTileCard';
 
 interface BottomDrawerProps {
   isOpen: boolean;
@@ -279,46 +256,21 @@ export const BottomDrawer: React.FC<BottomDrawerProps> = ({
               >
                 {t('sidebar.yourTiles')}
               </div>
-              <div className="p-3 flex flex-wrap gap-2" style={{ backgroundColor: 'var(--color-surface)' }}>
+              <div className="p-3 grid gap-2" style={{ backgroundColor: 'var(--color-surface)' }}>
                 {currentPlayer.tiles.map((tile: LocationTile, idx: number) => {
-                  const Ic = LOCATION_ICON[tile.location]
                   const isActive = activeTile === tile.location
                   const canUse = !tile.usedThisTurn &&
                     (phase === GamePhase.PlaceSettlements || phase === GamePhase.EndTurn)
                   return (
-                    <div
+                    <LocationTileCard
                       key={`${tile.location}-${idx}`}
-                      className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sm"
-                      style={{
-                        border: `2px solid ${isActive ? 'var(--color-warning)' : tile.usedThisTurn ? 'var(--card-border)' : 'var(--color-ink-green-300)'}`,
-                        backgroundColor: tile.usedThisTurn
-                          ? 'var(--color-warm-cream-100)'
-                          : isActive ? 'oklch(0.97 0.03 70)' : 'var(--color-ink-green-50)',
-                        opacity: tile.usedThisTurn ? 0.55 : 1,
-                      }}
-                    >
-                      <Ic size={16} />
-                      <span style={{ color: 'var(--color-text)' }}>{tLocation(t, tile.location)}</span>
-                      {canUse && (
-                        <button
-                          className="ml-1 text-xs font-bold px-1.5 py-0.5 rounded"
-                          style={{
-                            backgroundColor: isActive ? 'var(--color-warning)' : 'var(--color-success)',
-                            color: 'var(--button-text)',
-                          }}
-                          onClick={() =>
-                            isActive ? onCancelTile() : onActivateTile(tile.location)
-                          }
-                        >
-                          {isActive ? t('app.cancel') : t('app.use')}
-                        </button>
-                      )}
-                      {tile.usedThisTurn && (
-                        <span className="ml-1 text-xs italic" style={{ color: 'var(--color-stone-400)' }}>
-                          {t('app.used')}
-                        </span>
-                      )}
-                    </div>
+                      tile={tile}
+                      isActive={isActive}
+                      canUse={canUse}
+                      onUse={() => onActivateTile(tile.location)}
+                      onCancel={onCancelTile}
+                      compact
+                    />
                   )
                 })}
               </div>

--- a/src/i18n/formatters.ts
+++ b/src/i18n/formatters.ts
@@ -15,6 +15,10 @@ export function tLocation(t: TFunction, location: Location): string {
   return t(`location.${location}`);
 }
 
+export function tLocationDescription(t: TFunction, location: Location): string {
+  return t(`locationDescription.${location}`);
+}
+
 export function tObjective(t: TFunction, objective: ObjectiveCard): string {
   return t(`objective.${objective}`);
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -34,6 +34,16 @@ export const en = {
     Oracle: 'Oracle',
     Tavern: 'Tavern',
   },
+  locationDescription: {
+    Farm: 'Place 1 extra settlement on any empty Grass cell.',
+    Harbor: 'Place 1 extra settlement on any empty buildable cell adjacent to Water.',
+    Oasis: 'Place 1 extra settlement on any empty Desert cell.',
+    Tower: 'Place 1 extra settlement on an empty border cell or next to Mountain.',
+    Paddock: 'Move 1 of your settlements to an empty buildable cell up to 2 hexes away.',
+    Barn: 'Move 1 of your settlements to any empty cell with the same terrain type.',
+    Oracle: 'Place 1 extra settlement on an empty buildable cell adjacent to your settlements.',
+    Tavern: 'Place 1 extra settlement at either end of one of your horizontal settlement rows.',
+  },
   objective: {
     Fisherman: 'Fisherman',
     Miners: 'Miners',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -34,6 +34,16 @@ export const zhTW = {
     Oracle: '神諭',
     Tavern: '酒館',
   },
+  locationDescription: {
+    Farm: '在任意空的草原格放置 1 個額外聚落。',
+    Harbor: '在任意空的可建造且相鄰水域的格子放置 1 個額外聚落。',
+    Oasis: '在任意空的沙漠格放置 1 個額外聚落。',
+    Tower: '在空的邊界格，或相鄰山脈的格子放置 1 個額外聚落。',
+    Paddock: '將你的 1 個聚落移動到 2 格內空的可建造格。',
+    Barn: '將你的 1 個聚落移動到任意空的相同地形格。',
+    Oracle: '在任意空的可建造且相鄰你聚落的格子放置 1 個額外聚落。',
+    Tavern: '在你的任一水平聚落列兩端放置 1 個額外聚落。',
+  },
   objective: {
     Fisherman: '漁夫',
     Miners: '礦工',

--- a/tests/e2e/location-tiles.spec.ts
+++ b/tests/e2e/location-tiles.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+import { SetupPage } from '../pages/SetupPage';
+import { GamePage } from '../pages/GamePage';
+
+async function grantLocationTiles(page: import('@playwright/test').Page) {
+  await page.evaluate(async () => {
+    const { useGameStore } = await import('/src/store/gameStore.ts');
+    const { Location } = await import('/src/core/terrain.ts');
+    const { GamePhase } = await import('/src/types/index.ts');
+    const state = useGameStore.getState();
+
+    useGameStore.setState({
+      phase: GamePhase.EndTurn,
+      players: state.players.map((player, index) =>
+        index === 0
+          ? {
+              ...player,
+              tiles: [
+                { location: Location.Farm, usedThisTurn: false },
+                { location: Location.Paddock, usedThisTurn: true },
+              ],
+            }
+          : player
+      ),
+    });
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('i18nextLng', 'en');
+  });
+});
+
+test('desktop location tiles: cards explain each tile ability', async ({ page }) => {
+  const setupPage = new SetupPage(page);
+  const gamePage = new GamePage(page);
+
+  await setupPage.goto(42);
+  await setupPage.startGame();
+  await expect(gamePage.header).toBeVisible();
+  await grantLocationTiles(page);
+
+  const tiles = page.getByRole('region', { name: 'Your Location Tiles' }).first();
+  await expect(tiles.getByTestId('location-tile-card')).toHaveCount(2);
+  await expect(tiles).toContainText('Farm');
+  await expect(tiles).toContainText('Place 1 extra settlement on any empty Grass cell.');
+  await expect(tiles).toContainText('Paddock');
+  await expect(tiles).toContainText('Move 1 of your settlements to an empty buildable cell up to 2 hexes away.');
+  await expect(tiles).toContainText('Used');
+});
+
+test('mobile location tiles: drawer shows ability descriptions', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 });
+  const setupPage = new SetupPage(page);
+  const gamePage = new GamePage(page);
+
+  await setupPage.goto(42);
+  await setupPage.startGame();
+  await expect(gamePage.header).toBeVisible();
+  await grantLocationTiles(page);
+
+  const drawer = page.getByRole('region', { name: 'Game controls' });
+  await drawer.getByLabel('Open game panel').click();
+
+  const tiles = drawer.getByRole('region', { name: 'Your Location Tiles' });
+  await expect(tiles.getByTestId('location-tile-card')).toHaveCount(2);
+  await expect(tiles).toContainText('Place 1 extra settlement on any empty Grass cell.');
+  await expect(tiles).toContainText('Move 1 of your settlements to an empty buildable cell up to 2 hexes away.');
+});


### PR DESCRIPTION
## Summary
- replace name-only location tile chips with cards that explain each tile ability
- add EN and zh-TW descriptions for all playable location tiles
- reuse the same card UI in desktop sidebar and mobile drawer, including Use/Cancel/Used state
- add unit and Playwright coverage for location tile descriptions

## Verification
- npm run lint
- npm run build
- npm test -- --run
- PLAYWRIGHT_BASE_URL=http://127.0.0.1:5185 npx playwright test --project=chromium --retries=0
- node ~/HurricaneCore/eye/dist/cli.js detect-changes --staged --human
- CEO Playwright screenshot: /Users/yinghaowang/vscode/developer/workspace/tmp/kingdom-builder-location-tile-rules-desktop.png

## Security
- Pure UI/i18n display change. No auth, websocket, scoring logic, location logic, persistence key, external endpoint, or secret handling changes. Security double review not triggered.