### PR TITLE
Fix location tile cancel activation flow

### DIFF
--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -606,7 +606,7 @@ export const gameStore = create<GameState>((set, get) => ({
           state.currentTerrainCard.terrain,
           state.players[state.currentPlayerIndex].id
         )
-        : state.validPlacements;
+        : [];
 
     set({ ...resetTileState(), validPlacements: restored });
   },

--- a/tests/e2e/location-tile-activation.spec.ts
+++ b/tests/e2e/location-tile-activation.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect, type Page } from '@playwright/test';
+import { SetupPage } from '../pages/SetupPage';
+import { GamePage } from '../pages/GamePage';
+
+async function grantFarmTile(page: Page, phase: 'DrawCard' | 'EndTurn' = 'EndTurn') {
+  await page.evaluate(async ({ phase }) => {
+    const { useGameStore } = await import('/src/store/gameStore.ts');
+    const { Location } = await import('/src/core/terrain.ts');
+    const { GamePhase } = await import('/src/types/index.ts');
+    const state = useGameStore.getState();
+
+    useGameStore.setState({
+      phase: phase === 'EndTurn' ? GamePhase.EndTurn : GamePhase.DrawCard,
+      validPlacements: [],
+      players: state.players.map((player, index) =>
+        index === 0
+          ? {
+              ...player,
+              tiles: [{ location: Location.Farm, usedThisTurn: false }],
+            }
+          : player
+      ),
+    });
+  }, { phase });
+}
+
+async function grantFarmTileDuringForestPlacement(page: Page) {
+  await page.evaluate(async () => {
+    const { useGameStore } = await import('/src/store/gameStore.ts');
+    const { Location, Terrain } = await import('/src/core/terrain.ts');
+    const { getValidPlacements } = await import('/src/core/rules.ts');
+    const { GamePhase } = await import('/src/types/index.ts');
+    const state = useGameStore.getState();
+    const player = state.players[0];
+    const currentTerrainCard = { terrain: Terrain.Forest };
+
+    useGameStore.setState({
+      phase: GamePhase.PlaceSettlements,
+      currentTerrainCard,
+      remainingPlacements: 3,
+      validPlacements: getValidPlacements(state.board, Terrain.Forest, player.id),
+      players: state.players.map((existingPlayer, index) =>
+        index === 0
+          ? {
+              ...existingPlayer,
+              tiles: [{ location: Location.Farm, usedThisTurn: false }],
+            }
+          : existingPlayer
+      ),
+    });
+  });
+}
+
+async function currentFarmState(page: Page) {
+  return page.evaluate(async () => {
+    const { useGameStore } = await import('/src/store/gameStore.ts');
+    const { Location } = await import('/src/core/terrain.ts');
+    const { Terrain } = await import('/src/core/terrain.ts');
+    const state = useGameStore.getState();
+    const player = state.players[0];
+    const farm = player.tiles.find(tile => tile.location === Location.Farm);
+    const terrains = state.validPlacements.map(coord => state.board.getCell(coord)?.terrain);
+
+    return {
+      activeTile: state.activeTile,
+      farmUsed: farm?.usedThisTurn ?? null,
+      validCount: state.validPlacements.length,
+      allValidAreGrass: terrains.length > 0 && terrains.every(terrain => terrain === Terrain.Grass),
+    };
+  });
+}
+
+async function currentPlacementState(page: Page) {
+  return page.evaluate(async () => {
+    const { useGameStore } = await import('/src/store/gameStore.ts');
+    const state = useGameStore.getState();
+    const terrains = state.validPlacements.map(coord => state.board.getCell(coord)?.terrain);
+
+    return {
+      activeTile: state.activeTile,
+      terrain: state.currentTerrainCard?.terrain ?? null,
+      validCount: state.validPlacements.length,
+      allValidMatchTerrain:
+        !!state.currentTerrainCard &&
+        terrains.length > 0 &&
+        terrains.every(terrain => terrain === state.currentTerrainCard?.terrain),
+    };
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('i18nextLng', 'en');
+  });
+});
+
+test('location tile activation: Farm use highlights grass cells and marks the tile used', async ({ page }) => {
+  const setupPage = new SetupPage(page);
+  const gamePage = new GamePage(page);
+
+  await setupPage.goto(42);
+  await setupPage.startGame();
+  await expect(gamePage.header).toBeVisible();
+  await grantFarmTile(page);
+
+  const farmCard = page.getByTestId('location-tile-card').filter({ hasText: 'Farm' }).first();
+  await farmCard.getByRole('button', { name: 'Use' }).click();
+
+  const activated = await currentFarmState(page);
+  expect(activated.activeTile).toBe('Farm');
+  expect(activated.validCount).toBeGreaterThan(0);
+  expect(activated.allValidAreGrass).toBe(true);
+  await expect(gamePage.validCells.first()).toBeVisible();
+
+  await gamePage.clickValidCell();
+
+  await expect(farmCard).toContainText('Used');
+  const used = await currentFarmState(page);
+  expect(used.activeTile).toBeNull();
+  expect(used.farmUsed).toBe(true);
+  expect(used.validCount).toBe(0);
+});
+
+test('location tile activation: Cancel clears Farm highlights and keeps the tile available', async ({ page }) => {
+  const setupPage = new SetupPage(page);
+  const gamePage = new GamePage(page);
+
+  await setupPage.goto(42);
+  await setupPage.startGame();
+  await expect(gamePage.header).toBeVisible();
+  await grantFarmTile(page);
+
+  const farmCard = page.getByTestId('location-tile-card').filter({ hasText: 'Farm' }).first();
+  await farmCard.getByRole('button', { name: 'Use' }).click();
+  expect((await currentFarmState(page)).validCount).toBeGreaterThan(0);
+
+  await farmCard.getByRole('button', { name: 'Cancel' }).click();
+
+  await expect(farmCard.getByRole('button', { name: 'Use' })).toBeVisible();
+  const canceled = await currentFarmState(page);
+  expect(canceled.activeTile).toBeNull();
+  expect(canceled.farmUsed).toBe(false);
+  expect(canceled.validCount).toBe(0);
+  await expect(gamePage.validCells).toHaveCount(0);
+});
+
+test('location tile activation: Cancel during placement restores terrain placements', async ({ page }) => {
+  const setupPage = new SetupPage(page);
+  const gamePage = new GamePage(page);
+
+  await setupPage.goto(42);
+  await setupPage.startGame();
+  await expect(gamePage.header).toBeVisible();
+  await grantFarmTileDuringForestPlacement(page);
+
+  const before = await currentPlacementState(page);
+  expect(before.terrain).toBe('Forest');
+  expect(before.validCount).toBeGreaterThan(0);
+  expect(before.allValidMatchTerrain).toBe(true);
+
+  const farmCard = page.getByTestId('location-tile-card').filter({ hasText: 'Farm' }).first();
+  await farmCard.getByRole('button', { name: 'Use' }).click();
+  const activated = await currentFarmState(page);
+  expect(activated.allValidAreGrass).toBe(true);
+
+  await farmCard.getByRole('button', { name: 'Cancel' }).click();
+
+  const restored = await currentPlacementState(page);
+  expect(restored.activeTile).toBeNull();
+  expect(restored.terrain).toBe('Forest');
+  expect(restored.validCount).toBe(before.validCount);
+  expect(restored.allValidMatchTerrain).toBe(true);
+});
+
+test('location tile activation: tile actions are hidden before a tile can be used', async ({ page }) => {
+  const setupPage = new SetupPage(page);
+  const gamePage = new GamePage(page);
+
+  await setupPage.goto(42);
+  await setupPage.startGame();
+  await expect(gamePage.header).toBeVisible();
+  await grantFarmTile(page, 'DrawCard');
+
+  const farmCard = page.getByTestId('location-tile-card').filter({ hasText: 'Farm' }).first();
+  await expect(farmCard).toContainText('Place 1 extra settlement on any empty Grass cell.');
+  await expect(farmCard.getByRole('button', { name: 'Use' })).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- fix Location Tile cancel behavior so EndTurn tile highlights are cleared instead of left active after Cancel
- keep PlaceSettlements cancel behavior restoring the original terrain-card valid placements
- add Playwright E2E coverage for Farm Use, Used state, Cancel cleanup, placement-phase restore, and hidden actions before a tile can be used

## Verification
- npm run lint
- npm run build
- npm test -- --run
- PLAYWRIGHT_BASE_URL=http://127.0.0.1:5197 npx playwright test --project=chromium --retries=0
- PLAYWRIGHT_BASE_URL=http://127.0.0.1:5196 npx playwright test tests/e2e/location-tile-activation.spec.ts --project=chromium --retries=0
- node ~/HurricaneCore/eye/dist/cli.js detect-changes --staged --human
- CEO Playwright proof: Farm activation shows 119 valid Grass placements and allValidAreGrass=true

## Double Review
- Sonnet CISO/rules review: PASS
- Confirmed PlaceSettlements cancel restore path remains intact
- No security, websocket, scoring, localStorage key, external endpoint, auth, or secret changes
