### PR TITLE
Let bots use placement location tiles

### DIFF
--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -20,7 +20,7 @@ import {
   scoreObjectiveCard,
 } from '../core/scoring';
 import { GameAction, UndoSnapshot } from '../types/history';
-import { selectBestMoves } from '../ai/botPlayer';
+import { evaluateMove, selectBestMoves } from '../ai/botPlayer';
 
 // ────────────────────────────────────────────────────
 // State shape
@@ -94,6 +94,15 @@ const PLAYER_COLORS = [
   '#95E1D3', // Mint
 ];
 
+const BOT_PLACEMENT_TILES = new Set<Location>([
+  Location.Farm,
+  Location.Harbor,
+  Location.Oasis,
+  Location.Tower,
+  Location.Oracle,
+  Location.Tavern,
+]);
+
 // ────────────────────────────────────────────────────
 // Helpers
 // ────────────────────────────────────────────────────
@@ -117,6 +126,22 @@ function buildPlayerScores(
       castleScore + objectiveScores.reduce((s, o) => s + o.score, 0);
     return { playerId: player.id, castleScore, objectiveScores, totalScore };
   });
+}
+
+function chooseBotTilePlacement(
+  board: Board,
+  playerId: number,
+  location: Location
+): AxialCoord | null {
+  const options = getExtraPlacementPositions(location, board, playerId);
+  if (options.length === 0) return null;
+
+  return [...options].sort((a, b) => {
+    const scoreDelta = evaluateMove(board, b, playerId) - evaluateMove(board, a, playerId);
+    if (scoreDelta !== 0) return scoreDelta;
+    if (a.r !== b.r) return a.r - b.r;
+    return a.q - b.q;
+  })[0] ?? null;
 }
 
 function resetTileState() {
@@ -557,6 +582,33 @@ export const gameStore = create<GameState>((set, get) => ({
       } else {
         _consecutiveEmptyTurns = 0;
       }
+
+      const botTurnState = get();
+      const botPlayer = botTurnState.players[botTurnState.currentPlayerIndex];
+      if (botPlayer?.isBot) {
+        for (const tile of [...botPlayer.tiles]) {
+          const latest = get();
+          const latestPlayer = latest.players[latest.currentPlayerIndex];
+          if (!latestPlayer?.isBot || latestPlayer.remainingSettlements <= 0) break;
+          if (latest.phase !== GamePhase.EndTurn && latest.phase !== GamePhase.PlaceSettlements) break;
+          if (tile.usedThisTurn || !BOT_PLACEMENT_TILES.has(tile.location)) continue;
+
+          const coord = chooseBotTilePlacement(latest.board, latestPlayer.id, tile.location);
+          if (!coord) continue;
+
+          get().activateTile(tile.location);
+          const activated = get();
+          const validCoord = activated.validPlacements.find(
+            c => c.q === coord.q && c.r === coord.r
+          );
+          if (validCoord) {
+            get().applyTilePlacement(validCoord);
+          } else {
+            get().cancelTile();
+          }
+        }
+      }
+
       get().endTurn();
     }, STEP_MS * (moves.length + 1));
   },
@@ -624,7 +676,9 @@ export const gameStore = create<GameState>((set, get) => ({
     currentPlayer.remainingSettlements--;
 
     const tileLocation = state.activeTile;
-    const tile = currentPlayer.tiles.find(t => t.location === tileLocation);
+    const tile = currentPlayer.tiles.find(
+      t => t.location === tileLocation && !t.usedThisTurn
+    );
     if (tile) tile.usedThisTurn = true;
 
     const { updatedAcquiredLocations, acquiredLocationKeys, acquiredTileLocs } =
@@ -706,7 +760,9 @@ export const gameStore = create<GameState>((set, get) => ({
     const idx = currentPlayer.settlements.findIndex(s => hexToKey(s) === fromKey);
     if (idx !== -1) currentPlayer.settlements[idx] = to;
 
-    const tile = currentPlayer.tiles.find(t => t.location === tileLocation);
+    const tile = currentPlayer.tiles.find(
+      t => t.location === tileLocation && !t.usedThisTurn
+    );
     if (tile) tile.usedThisTurn = true;
 
     const restoredValid =

--- a/src/test/gameStore.botTiles.test.ts
+++ b/src/test/gameStore.botTiles.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useGameStore } from '../store/gameStore';
+import { Location, Terrain } from '../core/terrain';
+import { BotDifficulty, GamePhase, type PlayerConfig } from '../types';
+
+const players: PlayerConfig[] = [
+  { name: 'Human', type: 'human', difficulty: BotDifficulty.Medium },
+  { name: 'Bot', type: 'bot', difficulty: BotDifficulty.Medium },
+];
+
+function setupBotFarmTurn() {
+  useGameStore.getState().initGame(players, {
+    boardSize: 'small',
+    objectiveCount: 3,
+    enableUndo: true,
+  });
+
+  const state = useGameStore.getState();
+  for (const cell of state.board.getAllCells()) {
+    cell.terrain = Terrain.Grass;
+    cell.location = undefined;
+    cell.settlement = undefined;
+  }
+
+  useGameStore.setState({
+    currentPlayerIndex: 1,
+    phase: GamePhase.DrawCard,
+    currentTerrainCard: null,
+    deck: [{ terrain: Terrain.Grass }],
+    validPlacements: [],
+    players: state.players.map((player, index) =>
+      index === 1
+        ? {
+            ...player,
+            settlements: [],
+            remainingSettlements: 40,
+            tiles: [{ location: Location.Farm, usedThisTurn: false }],
+          }
+        : player
+    ),
+  });
+}
+
+function grantBotFarmTiles(count: number) {
+  const state = useGameStore.getState();
+  useGameStore.setState({
+    players: state.players.map((player, index) =>
+      index === 1
+        ? {
+            ...player,
+            tiles: Array.from({ length: count }, () => ({
+              location: Location.Farm,
+              usedThisTurn: false,
+            })),
+          }
+        : player
+    ),
+  });
+}
+
+describe('Bot location tiles', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setupBotFarmTurn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses an available placement tile before ending its turn', async () => {
+    useGameStore.getState().triggerBotTurn();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const state = useGameStore.getState();
+    const bot = state.players[1];
+    const tileAction = state.history.find(action => action.type === 'TILE_PLACEMENT');
+
+    expect(state.currentPlayerIndex).toBe(0);
+    expect(state.phase).toBe(GamePhase.DrawCard);
+    expect(bot.settlements).toHaveLength(4);
+    expect(bot.remainingSettlements).toBe(36);
+    expect(tileAction).toMatchObject({
+      type: 'TILE_PLACEMENT',
+      playerId: 2,
+      tile: Location.Farm,
+    });
+  });
+
+  it('marks each duplicate placement tile copy as used when both are played', () => {
+    grantBotFarmTiles(2);
+    useGameStore.setState({ phase: GamePhase.EndTurn });
+
+    useGameStore.getState().activateTile(Location.Farm);
+    useGameStore.getState().applyTilePlacement(useGameStore.getState().validPlacements[0]);
+    useGameStore.getState().activateTile(Location.Farm);
+    useGameStore.getState().applyTilePlacement(useGameStore.getState().validPlacements[0]);
+
+    const state = useGameStore.getState();
+    const bot = state.players[1];
+    const tileActions = state.history.filter(action => action.type === 'TILE_PLACEMENT');
+
+    expect(tileActions).toHaveLength(2);
+    expect(bot.tiles).toEqual([
+      { location: Location.Farm, usedThisTurn: true },
+      { location: Location.Farm, usedThisTurn: true },
+    ]);
+  });
+});

--- a/tests/e2e/bot-location-tile.spec.ts
+++ b/tests/e2e/bot-location-tile.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect, type Page } from '@playwright/test';
+import { SetupPage } from '../pages/SetupPage';
+import { GamePage } from '../pages/GamePage';
+
+async function setupBotFarmTurn(page: Page) {
+  await page.evaluate(async () => {
+    const { useGameStore } = await import('/src/store/gameStore.ts');
+    const { Location, Terrain } = await import('/src/core/terrain.ts');
+    const { GamePhase } = await import('/src/types/index.ts');
+    const state = useGameStore.getState();
+    for (const cell of state.board.getAllCells()) {
+      cell.terrain = Terrain.Grass;
+      cell.location = undefined;
+      cell.settlement = undefined;
+    }
+
+    useGameStore.setState({
+      currentPlayerIndex: 1,
+      phase: GamePhase.DrawCard,
+      currentTerrainCard: null,
+      deck: [{ terrain: Terrain.Grass }],
+      validPlacements: [],
+      players: state.players.map((player, index) =>
+        index === 1
+          ? {
+              ...player,
+              isBot: true,
+              settlements: [],
+              remainingSettlements: 40,
+              tiles: [{ location: Location.Farm, usedThisTurn: false }],
+            }
+          : player
+      ),
+    });
+  });
+}
+
+async function botTileResult(page: Page) {
+  return page.evaluate(async () => {
+    const { useGameStore } = await import('/src/store/gameStore.ts');
+    const state = useGameStore.getState();
+    const bot = state.players[1];
+    const tileAction = state.history.find(action => action.type === 'TILE_PLACEMENT');
+
+    return {
+      currentPlayerIndex: state.currentPlayerIndex,
+      phase: state.phase,
+      botSettlements: bot.settlements.length,
+      botRemaining: bot.remainingSettlements,
+      tileAction,
+    };
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('i18nextLng', 'en');
+  });
+});
+
+test('bot uses a placement location tile during its automatic turn', async ({ page }) => {
+  const setupPage = new SetupPage(page);
+  const gamePage = new GamePage(page);
+
+  await setupPage.goto(42);
+  await setupPage.startGame();
+  await expect(gamePage.header).toBeVisible();
+  await setupBotFarmTurn(page);
+
+  await page.evaluate(async () => {
+    const { useGameStore } = await import('/src/store/gameStore.ts');
+    useGameStore.getState().triggerBotTurn();
+  });
+
+  await expect.poll(async () => {
+    const result = await botTileResult(page);
+    return {
+      currentPlayerIndex: result.currentPlayerIndex,
+      phase: result.phase,
+      botSettlements: result.botSettlements,
+      hasTileAction: !!result.tileAction,
+    };
+  }, { timeout: 5000 }).toEqual({
+    currentPlayerIndex: 0,
+    phase: 'DrawCard',
+    botSettlements: 4,
+    hasTileAction: true,
+  });
+
+  const result = await botTileResult(page);
+  expect(result.currentPlayerIndex).toBe(0);
+  expect(result.phase).toBe('DrawCard');
+  expect(result.botSettlements).toBe(4);
+  expect(result.botRemaining).toBe(36);
+  expect(result.tileAction).toMatchObject({
+    type: 'TILE_PLACEMENT',
+    playerId: 2,
+    tile: 'Farm',
+  });
+});


### PR DESCRIPTION
## Summary
- Let bot turns use available placement-type location tiles before ending the turn
- Keep Bot tile choices constrained through the same valid placement helpers as human tile actions
- Fix duplicate location tile copies so each unused copy is marked when played
- Add unit and Chromium E2E coverage for Bot Farm tile usage

## Verification
- npm run lint
- npm run build
- npm test -- --run
- PLAYWRIGHT_BASE_URL=http://127.0.0.1:5206 npx playwright test --project=chromium --retries=0
- CEO Playwright proof: Bot history becomes PLACE_SETTLEMENT x3 + TILE_PLACEMENT, Player 2 remaining settlements 36
- eye detect-changes --staged --human
- CISO/Sonnet double review: PASS

## Follow-up
- Existing duplicate tile + undo unmark behavior should be tracked separately; not introduced by this PR.