### PR TITLE
fix(undo): #125 duplicate location tile undo tracking — 改用 tileUsedIndex 定位

### DIFF
--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -676,9 +676,10 @@ export const gameStore = create<GameState>((set, get) => ({
     currentPlayer.remainingSettlements--;
 
     const tileLocation = state.activeTile;
-    const tile = currentPlayer.tiles.find(
+    const tileIdx = currentPlayer.tiles.findIndex(
       t => t.location === tileLocation && !t.usedThisTurn
     );
+    const tile = tileIdx !== -1 ? currentPlayer.tiles[tileIdx] : undefined;
     if (tile) tile.usedThisTurn = true;
 
     const { updatedAcquiredLocations, acquiredLocationKeys, acquiredTileLocs } =
@@ -711,6 +712,7 @@ export const gameStore = create<GameState>((set, get) => ({
       acquiredLocationKeys,
       acquiredTileLocs,
       tileUsed: tileLocation,
+      tileUsedIndex: tileIdx !== -1 ? tileIdx : undefined,
     };
 
     set({
@@ -760,9 +762,10 @@ export const gameStore = create<GameState>((set, get) => ({
     const idx = currentPlayer.settlements.findIndex(s => hexToKey(s) === fromKey);
     if (idx !== -1) currentPlayer.settlements[idx] = to;
 
-    const tile = currentPlayer.tiles.find(
+    const tileIdx = currentPlayer.tiles.findIndex(
       t => t.location === tileLocation && !t.usedThisTurn
     );
+    const tile = tileIdx !== -1 ? currentPlayer.tiles[tileIdx] : undefined;
     if (tile) tile.usedThisTurn = true;
 
     const restoredValid =
@@ -793,6 +796,7 @@ export const gameStore = create<GameState>((set, get) => ({
       acquiredLocationKeys: [],
       acquiredTileLocs: [],
       tileUsed: tileLocation,
+      tileUsedIndex: tileIdx !== -1 ? tileIdx : undefined,
       movedSettlementIdx: idx !== -1 ? idx : undefined,
     };
 
@@ -871,9 +875,15 @@ export const gameStore = create<GameState>((set, get) => ({
       );
       currentPlayer.remainingSettlements++;
 
-      // Un-mark tile as used
+      // Un-mark tile as used.
+      // Prefer tileUsedIndex for exact instance lookup (fixes duplicate-location
+      // bug #125). Fall back to .find() for old snapshots that lack the field
+      // (backwards-compat: snapshots from localStorage before this fix).
       if (snap.tileUsed) {
-        const usedTile = currentPlayer.tiles.find(t => t.location === snap.tileUsed);
+        const usedTile =
+          snap.tileUsedIndex !== undefined
+            ? currentPlayer.tiles[snap.tileUsedIndex]
+            : currentPlayer.tiles.find(t => t.location === snap.tileUsed);
         if (usedTile) usedTile.usedThisTurn = false;
       }
 
@@ -925,9 +935,15 @@ export const gameStore = create<GameState>((set, get) => ({
         currentPlayer.settlements[snap.movedSettlementIdx] = snap.fromCoord;
       }
 
-      // Un-mark tile as used
+      // Un-mark tile as used.
+      // Prefer tileUsedIndex for exact instance lookup (fixes duplicate-location
+      // bug #125). Fall back to .find() for old snapshots that lack the field
+      // (backwards-compat: snapshots from localStorage before this fix).
       if (snap.tileUsed) {
-        const usedTile = currentPlayer.tiles.find(t => t.location === snap.tileUsed);
+        const usedTile =
+          snap.tileUsedIndex !== undefined
+            ? currentPlayer.tiles[snap.tileUsedIndex]
+            : currentPlayer.tiles.find(t => t.location === snap.tileUsed);
         if (usedTile) usedTile.usedThisTurn = false;
       }
 

--- a/src/test/gameStore.undo.tileCopy.test.ts
+++ b/src/test/gameStore.undo.tileCopy.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for fix #125 — duplicate location tile undo tracking.
+ *
+ * When a player holds two tiles with the same Location (e.g. Farm×2),
+ * undoLastAction must restore the *correct* tile instance to usedThisTurn=false.
+ * Before the fix, `.find()` always returned the first match, so undoing the
+ * second use would incorrectly toggle the first tile.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useGameStore } from '../store/gameStore';
+import { GamePhase } from '../types';
+import { UndoSnapshot } from '../types/history';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Reset game state between tests. */
+function resetStore() {
+  useGameStore.getState().initGame(2);
+  useGameStore.getState().drawTerrainCard();
+}
+
+/**
+ * Build a minimal TILE_PLACEMENT UndoSnapshot that points at a specific tile
+ * index in the player's tiles array.
+ */
+function makeTilePlacementSnapshot(tileUsedIndex: number, tileLocation: 'Farm'): UndoSnapshot {
+  return {
+    type: 'TILE_PLACEMENT',
+    coord: { q: 0, r: 0 },
+    previousRemainingPlacements: 3,
+    previousPhase: GamePhase.PlaceSettlements,
+    acquiredLocationKeys: [],
+    acquiredTileLocs: [],
+    tileUsed: tileLocation as import('../core/terrain').Location,
+    tileUsedIndex,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// TC-1: Farm×2 — undo second use leaves first tile untouched
+// ---------------------------------------------------------------------------
+
+describe('fix #125 — duplicate location tile undo', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it('TC-1: Farm×2 undo second use — second tile restored, first stays used', () => {
+    // Inject two Farm tiles where [0].usedThisTurn=true, [1].usedThisTurn=true
+    // (simulating: player used both tiles this turn, snapshot was for index 1)
+    useGameStore.setState(state => ({
+      players: state.players.map((p, i) =>
+        i !== 0
+          ? p
+          : {
+              ...p,
+              tiles: [
+                { location: 'Farm' as import('../core/terrain').Location, usedThisTurn: true },
+                { location: 'Farm' as import('../core/terrain').Location, usedThisTurn: true },
+              ],
+            }
+      ),
+      canUndo: true,
+      undoUsedThisTurn: false,
+      // Snapshot targets the SECOND tile (index 1)
+      undoSnapshot: makeTilePlacementSnapshot(1, 'Farm'),
+    }));
+
+    useGameStore.getState().undoLastAction();
+
+    const tiles = useGameStore.getState().players[0].tiles;
+    // index 0 (first Farm) must remain used
+    expect(tiles[0].usedThisTurn).toBe(true);
+    // index 1 (second Farm) must be restored
+    expect(tiles[1].usedThisTurn).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-2: Single Farm — regression: undo still works correctly
+  // -------------------------------------------------------------------------
+
+  it('TC-2: single Farm undo regression — tile is correctly un-marked', () => {
+    useGameStore.setState(state => ({
+      players: state.players.map((p, i) =>
+        i !== 0
+          ? p
+          : {
+              ...p,
+              tiles: [
+                { location: 'Farm' as import('../core/terrain').Location, usedThisTurn: true },
+              ],
+            }
+      ),
+      canUndo: true,
+      undoUsedThisTurn: false,
+      undoSnapshot: makeTilePlacementSnapshot(0, 'Farm'),
+    }));
+
+    useGameStore.getState().undoLastAction();
+
+    const tiles = useGameStore.getState().players[0].tiles;
+    expect(tiles[0].usedThisTurn).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // TC-3: Farm×2 — undo first use leaves second tile untouched
+  // -------------------------------------------------------------------------
+
+  it('TC-3: Farm×2 undo first use — first tile restored, second unaffected', () => {
+    // [0].usedThisTurn=true, [1].usedThisTurn=false
+    // Snapshot targets index 0 (the first Farm was used)
+    useGameStore.setState(state => ({
+      players: state.players.map((p, i) =>
+        i !== 0
+          ? p
+          : {
+              ...p,
+              tiles: [
+                { location: 'Farm' as import('../core/terrain').Location, usedThisTurn: true },
+                { location: 'Farm' as import('../core/terrain').Location, usedThisTurn: false },
+              ],
+            }
+      ),
+      canUndo: true,
+      undoUsedThisTurn: false,
+      undoSnapshot: makeTilePlacementSnapshot(0, 'Farm'),
+    }));
+
+    useGameStore.getState().undoLastAction();
+
+    const tiles = useGameStore.getState().players[0].tiles;
+    // index 0 (first Farm) must be restored
+    expect(tiles[0].usedThisTurn).toBe(false);
+    // index 1 (second Farm) must remain untouched
+    expect(tiles[1].usedThisTurn).toBe(false);
+  });
+});

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -48,6 +48,15 @@ export interface UndoSnapshot {
   acquiredTileLocs: Location[];
   /** Location tile that was marked usedThisTurn by this action */
   tileUsed?: Location;
+  /**
+   * Index into player.tiles[] for the specific tile instance that was marked
+   * usedThisTurn. Used by undoLastAction to unmark the correct tile when the
+   * player holds duplicate location tiles (e.g. Farm×2).
+   *
+   * Backwards-compat: old snapshots (e.g. from localStorage) will not have
+   * this field → undoLastAction falls back to `.find(t.location === tileUsed)`.
+   */
+  tileUsedIndex?: number;
   /** Settlement index in player.settlements that was removed (TILE_MOVE only) */
   movedSettlementIdx?: number;
 }


### PR DESCRIPTION
## Closes #125

## 根因

`UndoSnapshot.tileUsed` 只存 `Location` 字串（如 `"Farm"`）。當玩家持有同 location 的兩張 tile（Farm×2），undoLastAction 的 `.find(t => t.location === snap.tileUsed)` 永遠命中陣列第一張，誤把第一張（而非實際被用的第二張）標回 `usedThisTurn = false`。

## 修法（最小異動）

### `src/types/history.ts`
- `UndoSnapshot` 新增 `tileUsedIndex?: number`（選用，保留 `tileUsed?: Location` 向後相容）

### `src/store/gameStore.ts`
- `applyTilePlacement`：`.find()` 改 `.findIndex()`，snapshot 多寫 `tileUsedIndex`
- `applyTileMove`：同上
- `undoLastAction`（TILE_PLACEMENT / TILE_MOVE 兩分支）：優先用 `tiles[snap.tileUsedIndex]` 定位，`tileUsedIndex` 為 undefined 時 fallback 至 `.find(t => t.location === snap.tileUsed)`

### `src/test/gameStore.undo.tileCopy.test.ts`（新增）
- TC-1：Farm×2 用兩張，undo 第二張 → 第二張 usedThisTurn=false，第一張仍 true
- TC-2：單張 Farm undo regression（舊行為不壞）
- TC-3：Farm×2 用第一張，undo → 第一張 usedThisTurn=false，第二張不受影響

## 向後相容說明

localStorage 內舊 undoSnapshot 無 `tileUsedIndex` 欄位，`snap.tileUsedIndex === undefined` 時走 fallback `.find()`，行為等同舊版，舊存檔完全相容。fallback 路徑在兩個 undo 分支均有明確註解標示。

## tiles 陣列索引穩定性確認

grep 確認 tiles 陣列在同一回合內只有以下異動：
- `tiles.push()`：`applyTileAcquisition`（新獲得 tile，僅在 placement 之後 append 到尾端，不影響既有 index）
- `tiles.slice(0, len - n)`：undo 時移除 acquiredTileLocs，發生在 tileUsedIndex 已使用之後，不影響 undo 當下的 index 定位
- 無 `splice` / `filter` / 插入中間的操作

結論：snapshot 記錄的 `tileUsedIndex` 在同一回合內指向的 tile 實例不會因其他 action 而失效。

## DoD

- `npx tsc --noEmit` → 0 errors
- `npx vitest run src/test/gameStore.undo.tileCopy.test.ts` → 3/3 pass
- `npx vitest run` → 341/341 pass（28 test files，無新增失敗）

🤖 Generated with [Claude Code](https://claude.com/claude-code)