### PR TITLE
feat(ui): #110 統一 ModalFrame — 四套 modal 共用框架 + useModal hook

### DIFF
--- a/src/components/Game/AchievementPanel.tsx
+++ b/src/components/Game/AchievementPanel.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { useAchievementStore, getUnlockedCount } from '../../store/achievementStore';
+import { ModalFrame } from '../UI/ModalFrame';
 
 interface AchievementPanelProps {
   onClose: () => void;
@@ -10,76 +11,61 @@ export function AchievementPanel({ onClose }: AchievementPanelProps) {
   const achievements = useAchievementStore((s) => s.achievements);
   const unlockedCount = getUnlockedCount(achievements);
 
-  return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label={t('achievement.panelLabel')}
-      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-    >
-      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-lg max-h-[80vh] flex flex-col overflow-hidden">
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b">
-          <div>
-            <h2 className="text-2xl font-bold">{t('achievement.heading')}</h2>
-            <p className="text-sm text-gray-500 mt-0.5">
-              {t('achievement.progress', {
-                unlocked: unlockedCount,
-                total: achievements.length,
-              })}
-            </p>
-          </div>
-          <button
-            onClick={onClose}
-            aria-label={t('achievement.close')}
-            className="text-gray-400 hover:text-gray-600 text-2xl leading-none"
-          >
-            ×
-          </button>
-        </div>
+  const kicker = t('achievement.progress', {
+    unlocked: unlockedCount,
+    total: achievements.length,
+  });
 
-        {/* Grid */}
-        <div className="overflow-y-auto p-6 grid grid-cols-2 sm:grid-cols-3 gap-4">
-          {achievements.map((a) => (
-            <div
-              key={a.id}
-              className={`rounded-xl border-2 p-4 flex flex-col items-center text-center gap-2 transition ${
-                a.unlocked
-                  ? 'border-yellow-400 bg-yellow-50'
-                  : 'border-gray-200 bg-gray-50 opacity-50 grayscale'
-              }`}
-              aria-label={
-                a.unlocked
-                  ? t('achievement.unlockedAria', { title: t(`achievement.items.${a.id}.title`) })
-                  : t('achievement.lockedAria', { title: t(`achievement.items.${a.id}.title`) })
-              }
-            >
-              <span className="text-4xl" aria-hidden="true">
-                {a.icon}
+  return (
+    <ModalFrame
+      isOpen
+      onClose={onClose}
+      ariaLabel={t('achievement.panelLabel')}
+      title={t('achievement.heading')}
+      kicker={kicker}
+    >
+      {/* Achievement grid */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+        {achievements.map((a) => (
+          <div
+            key={a.id}
+            className="rounded-xl p-4 flex flex-col items-center text-center gap-2 transition"
+            style={{
+              border: `2px solid ${a.unlocked ? 'var(--color-amber-400)' : 'var(--card-border)'}`,
+              backgroundColor: a.unlocked ? 'oklch(0.97 0.02 80)' : 'var(--color-warm-cream-50)',
+              opacity: a.unlocked ? 1 : 0.5,
+              filter: a.unlocked ? 'none' : 'grayscale(1)',
+            }}
+            aria-label={
+              a.unlocked
+                ? t('achievement.unlockedAria', { title: t(`achievement.items.${a.id}.title`) })
+                : t('achievement.lockedAria', { title: t(`achievement.items.${a.id}.title`) })
+            }
+          >
+            <span className="text-4xl" aria-hidden="true">
+              {a.icon}
+            </span>
+            <span className="text-sm font-semibold leading-tight" style={{ color: 'var(--color-text)' }}>
+              {t(`achievement.items.${a.id}.title`)}
+            </span>
+            <span className="text-xs leading-tight" style={{ color: 'var(--color-stone-500)' }}>
+              {t(`achievement.items.${a.id}.description`)}
+            </span>
+            {a.unlocked && a.unlockedAt && (
+              <span className="text-xs font-medium" style={{ color: 'var(--color-amber-700)' }}>
+                {t('achievement.unlockedOn', {
+                  date: new Date(a.unlockedAt).toLocaleDateString(),
+                })}
               </span>
-              <span className="text-sm font-semibold leading-tight">
-                {t(`achievement.items.${a.id}.title`)}
+            )}
+            {!a.unlocked && (
+              <span className="text-xs italic" style={{ color: 'var(--color-stone-400)' }}>
+                {t('achievement.locked')}
               </span>
-              <span className="text-xs text-gray-500 leading-tight">
-                {t(`achievement.items.${a.id}.description`)}
-              </span>
-              {a.unlocked && a.unlockedAt && (
-                <span className="text-xs text-yellow-600 font-medium">
-                  {t('achievement.unlockedOn', {
-                    date: new Date(a.unlockedAt).toLocaleDateString(),
-                  })}
-                </span>
-              )}
-              {!a.unlocked && (
-                <span className="text-xs text-gray-400 italic">{t('achievement.locked')}</span>
-              )}
-            </div>
-          ))}
-        </div>
+            )}
+          </div>
+        ))}
       </div>
-    </div>
+    </ModalFrame>
   );
 }

--- a/src/components/Game/LeaderboardModal.tsx
+++ b/src/components/Game/LeaderboardModal.tsx
@@ -4,6 +4,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { getTopEntries, getObjectiveComboKey, useLeaderboardStore } from '../../store/leaderboardStore';
 import { tObjective } from '../../i18n/formatters';
 import type { ObjectiveCard } from '../../core/scoring';
+import { ModalFrame } from '../UI/ModalFrame';
 
 interface LeaderboardModalProps {
   isOpen: boolean;
@@ -35,107 +36,115 @@ export const LeaderboardModal = React.memo(function LeaderboardModal({
     return getTopEntries(source, objectiveFilter);
   }, [activeTab, globalEntries, localEntries, objectiveFilter]);
 
-  if (!isOpen) return null;
+  const footer = (
+    <button
+      onClick={clearLocalEntries}
+      className="text-sm font-semibold"
+      style={{ color: 'var(--color-danger)' }}
+    >
+      {t('leaderboard.clearLocal')}
+    </button>
+  );
 
   return (
-    <div className="fixed inset-0 z-[60] bg-black/70 flex items-center justify-center px-4">
-      <div className="bg-white rounded-xl shadow-2xl p-6 max-w-2xl w-full max-h-[85vh] overflow-y-auto">
-        <div className="flex items-center justify-between gap-3 mb-4">
-          <h3 className="text-2xl font-bold">{t('leaderboard.heading')}</h3>
-          <button
-            onClick={onClose}
-            className="text-sm font-semibold text-gray-600 hover:text-gray-900"
-            aria-label={t('leaderboard.close')}
-          >
-            {t('leaderboard.close')}
-          </button>
-        </div>
+    <ModalFrame
+      isOpen={isOpen}
+      onClose={onClose}
+      ariaLabel={t('leaderboard.heading')}
+      title={t('leaderboard.heading')}
+      footer={footer}
+    >
+      {/* Tab switcher */}
+      <div className="flex items-center gap-2 mb-4">
+        <button
+          onClick={() => setActiveTab('local')}
+          className="px-3 py-1.5 text-sm rounded-full font-semibold transition"
+          style={
+            activeTab === 'local'
+              ? { backgroundColor: 'var(--button-primary-bg)', color: 'var(--button-text)' }
+              : { backgroundColor: 'var(--color-stone-100)', color: 'var(--color-stone-700)' }
+          }
+        >
+          {t('leaderboard.localTab')}
+        </button>
+        <button
+          onClick={() => setActiveTab('global')}
+          className="px-3 py-1.5 text-sm rounded-full font-semibold transition"
+          style={
+            activeTab === 'global'
+              ? { backgroundColor: 'var(--button-primary-bg)', color: 'var(--button-text)' }
+              : { backgroundColor: 'var(--color-stone-100)', color: 'var(--color-stone-700)' }
+          }
+        >
+          {t('leaderboard.globalTab')}
+        </button>
+      </div>
 
-        <div className="flex items-center gap-2 mb-4">
-          <button
-            onClick={() => setActiveTab('local')}
-            className={`px-3 py-1.5 text-sm rounded-full font-semibold ${
-              activeTab === 'local'
-                ? 'bg-blue-600 text-white'
-                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-            }`}
-          >
-            {t('leaderboard.localTab')}
-          </button>
-          <button
-            onClick={() => setActiveTab('global')}
-            className={`px-3 py-1.5 text-sm rounded-full font-semibold ${
-              activeTab === 'global'
-                ? 'bg-blue-600 text-white'
-                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-            }`}
-          >
-            {t('leaderboard.globalTab')}
-          </button>
-        </div>
+      {/* Objective filter */}
+      <div className="mb-4">
+        <label
+          className="text-sm mr-2"
+          htmlFor="objective-filter"
+          style={{ color: 'var(--color-stone-600)' }}
+        >
+          {t('leaderboard.filterByObjective')}
+        </label>
+        <select
+          id="objective-filter"
+          value={objectiveFilter}
+          onChange={(event) => setObjectiveFilter(event.target.value)}
+          className="rounded px-2 py-1 text-sm"
+          style={{ border: '1px solid var(--card-border)' }}
+        >
+          {objectiveOptions.map((combo) => (
+            <option key={combo} value={combo}>
+              {combo === '__all__'
+                ? t('leaderboard.filterAll')
+                : combo
+                    .split('|')
+                    .map((card) => tObjective(t, card as ObjectiveCard))
+                    .join(' · ')}
+            </option>
+          ))}
+        </select>
+      </div>
 
-        <div className="mb-4">
-          <label className="text-sm text-gray-600 mr-2" htmlFor="objective-filter">
-            {t('leaderboard.filterByObjective')}
-          </label>
-          <select
-            id="objective-filter"
-            value={objectiveFilter}
-            onChange={(event) => setObjectiveFilter(event.target.value)}
-            className="border rounded px-2 py-1 text-sm"
-          >
-            {objectiveOptions.map((combo) => (
-              <option key={combo} value={combo}>
-                {combo === '__all__'
-                  ? t('leaderboard.filterAll')
-                  : combo
-                      .split('|')
-                      .map((card) => tObjective(t, card as ObjectiveCard))
-                      .join(' · ')}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        {displayedEntries.length === 0 ? (
-          <p className="text-gray-500 text-sm">{t('leaderboard.empty')}</p>
-        ) : (
-          <ol className="space-y-2 mb-4">
-            {displayedEntries.map((entry, index) => (
-              <li
-                key={`${entry.playerName}-${entry.date}-${index}`}
-                className="border rounded-lg p-3 bg-gray-50"
-              >
-                <div className="flex justify-between gap-3">
-                  <div>
-                    <p className="font-semibold">
-                      #{index + 1} · {entry.playerName}
-                    </p>
-                    <p className="text-xs text-gray-500">
-                      {t('leaderboard.meta', {
-                        date: new Date(entry.date).toLocaleDateString(i18n.language),
-                        playerCount: entry.playerCount,
-                      })}
-                    </p>
-                  </div>
-                  <p className="text-xl font-bold">
-                    {entry.score} {t('common.pointsShort')}
+      {/* Entries list */}
+      {displayedEntries.length === 0 ? (
+        <p className="text-sm" style={{ color: 'var(--color-stone-500)' }}>
+          {t('leaderboard.empty')}
+        </p>
+      ) : (
+        <ol className="space-y-2">
+          {displayedEntries.map((entry, index) => (
+            <li
+              key={`${entry.playerName}-${entry.date}-${index}`}
+              className="rounded-lg p-3"
+              style={{
+                border: '1px solid var(--card-border)',
+                backgroundColor: 'var(--color-warm-cream-50)',
+              }}
+            >
+              <div className="flex justify-between gap-3">
+                <div>
+                  <p className="font-semibold" style={{ color: 'var(--color-text)' }}>
+                    #{index + 1} · {entry.playerName}
+                  </p>
+                  <p className="text-xs" style={{ color: 'var(--color-stone-500)' }}>
+                    {t('leaderboard.meta', {
+                      date: new Date(entry.date).toLocaleDateString(i18n.language),
+                      playerCount: entry.playerCount,
+                    })}
                   </p>
                 </div>
-              </li>
-            ))}
-          </ol>
-        )}
-
-        <div className="flex justify-end">
-          <button
-            onClick={clearLocalEntries}
-            className="text-sm font-semibold text-red-600 hover:text-red-700"
-          >
-            {t('leaderboard.clearLocal')}
-          </button>
-        </div>
-      </div>
-    </div>
+                <p className="text-xl font-bold" style={{ color: 'var(--color-text)' }}>
+                  {entry.score} {t('common.pointsShort')}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </ModalFrame>
   );
 });

--- a/src/components/Game/ReplayModal.tsx
+++ b/src/components/Game/ReplayModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useReplayStore } from '../../store/replayStore';
 import { ReplayList } from './ReplayList';
 import { ReplayViewer } from './ReplayViewer';
+import { ModalFrame } from '../UI/ModalFrame';
 
 interface ReplayModalProps {
   isOpen: boolean;
@@ -16,46 +17,24 @@ export const ReplayModal = React.memo(function ReplayModal({ isOpen, onClose }: 
   const selectReplay = useReplayStore((s) => s.selectReplay);
   const deleteReplay = useReplayStore((s) => s.deleteReplay);
 
-  if (!isOpen) return null;
-
   const selectedReplay = replays.find((r) => r.id === selectedReplayId) ?? null;
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label={t('replay.heading')}
-      className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50 p-4"
+    <ModalFrame
+      isOpen={isOpen}
+      onClose={onClose}
+      ariaLabel={t('replay.heading')}
+      title={t('replay.heading')}
     >
-      <div className="bg-white rounded-xl shadow-2xl w-full max-w-lg flex flex-col max-h-[90vh]">
-        {/* Modal header */}
-        <div className="flex items-center justify-between p-4 border-b border-gray-200 shrink-0">
-          <h2 className="text-xl font-bold">{t('replay.heading')}</h2>
-          <button
-            onClick={onClose}
-            className="text-gray-500 hover:text-gray-800 transition text-lg font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600"
-            aria-label={t('replay.close')}
-          >
-            ✕
-          </button>
-        </div>
-
-        {/* Modal body */}
-        <div className="flex-1 overflow-y-auto p-4">
-          {selectedReplay ? (
-            <ReplayViewer
-              replay={selectedReplay}
-              onBack={() => selectReplay(null)}
-            />
-          ) : (
-            <ReplayList
-              replays={replays}
-              onSelect={(id) => selectReplay(id)}
-              onDelete={(id) => deleteReplay(id)}
-            />
-          )}
-        </div>
-      </div>
-    </div>
+      {selectedReplay ? (
+        <ReplayViewer replay={selectedReplay} onBack={() => selectReplay(null)} />
+      ) : (
+        <ReplayList
+          replays={replays}
+          onSelect={(id) => selectReplay(id)}
+          onDelete={(id) => deleteReplay(id)}
+        />
+      )}
+    </ModalFrame>
   );
 });

--- a/src/components/Tutorial/TutorialOverlay.tsx
+++ b/src/components/Tutorial/TutorialOverlay.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useCallback, useState } from 'react';
 import { useTutorialStore, TUTORIAL_STEPS } from '../../store/tutorialStore';
 import { useTranslation } from 'react-i18next';
+import { ModalFrame } from '../UI/ModalFrame';
+import type { ArrowDirection } from '../UI/ModalFrame';
 
 interface SpotlightRect {
   top: number;
@@ -22,6 +24,26 @@ function findTutorialTarget(targetElement?: string): HTMLElement | null {
   );
 }
 
+/**
+ * Derive arrow pointer direction from spotlight rect vs viewport centre.
+ * The tooltip card sits near screen centre, so we point toward the spotlight.
+ */
+function deriveArrowDirection(rect: SpotlightRect): ArrowDirection {
+  const viewportCentreX = window.innerWidth / 2;
+  const viewportCentreY = window.innerHeight / 2;
+  const spotlightCentreX = rect.left + rect.width / 2;
+  const spotlightCentreY = rect.top + rect.height / 2;
+
+  const dx = spotlightCentreX - viewportCentreX;
+  const dy = spotlightCentreY - viewportCentreY;
+
+  // Point the arrow toward the spotlight
+  if (Math.abs(dx) > Math.abs(dy)) {
+    return { side: dx > 0 ? 'right' : 'left', offsetPct: 50 };
+  }
+  return { side: dy > 0 ? 'bottom' : 'top', offsetPct: 50 };
+}
+
 export function TutorialOverlay() {
   const { t } = useTranslation();
   const { isActive, currentStepIndex, nextStep, prevStep, completeTutorial, dismissTutorial } =
@@ -32,7 +54,7 @@ export function TutorialOverlay() {
   const isLastStep = currentStepIndex === TUTORIAL_STEPS.length - 1;
   const isFirstStep = currentStepIndex === 0;
 
-  // Close on Escape key
+  // ESC → dismissTutorial (tutorial's ESC is dismiss, not close — kept here, not in useModal)
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === 'Escape') dismissTutorial();
@@ -51,6 +73,7 @@ export function TutorialOverlay() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [isActive, handleKeyDown]);
 
+  // Spotlight rect calculation — preserved verbatim
   useEffect(() => {
     if (!isActive || !step?.targetElement) {
       return;
@@ -101,104 +124,129 @@ export function TutorialOverlay() {
   const translatedDescription = t(`tutorial.steps.${stepI18nKey}.description`, { defaultValue: step.description });
   const shouldShowActionHint = step.advanceOn !== undefined && step.advanceOn !== 'none';
 
+  const arrowDirection: ArrowDirection | undefined = spotlightRect
+    ? deriveArrowDirection(spotlightRect)
+    : undefined;
+
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label={t('tutorial.dialogLabel')}
-      className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
-    >
-      <div className="absolute inset-0 bg-black/65 pointer-events-none" aria-hidden="true" />
+    <>
+      {/* Full-screen dimming layer (pointer-events none so clicks pass through to spotlight) */}
+      <div
+        aria-hidden="true"
+        className="fixed inset-0 z-[50] bg-black/65 pointer-events-none"
+      />
+
+      {/* Spotlight cutout */}
       {step.targetElement && spotlightRect && (
         <div
           data-testid="tutorial-spotlight"
           aria-hidden="true"
-          className="fixed rounded-xl border-4 border-yellow-300 shadow-[0_0_0_9999px_rgba(0,0,0,0.5),0_0_24px_rgba(250,204,21,0.9)] transition-all duration-200"
+          className="fixed rounded-xl border-4 border-yellow-300 shadow-[0_0_0_9999px_rgba(0,0,0,0.5),0_0_24px_rgba(250,204,21,0.9)] transition-all duration-200 z-[60]"
           style={spotlightRect}
         />
       )}
 
-      {/* Tooltip card – stop propagation so clicks inside don't close */}
+      {/* Tooltip card via ModalFrame coachmark variant */}
       <div
-        className="relative bg-white rounded-2xl shadow-2xl p-6 w-full max-w-md mx-4 flex flex-col gap-4 pointer-events-auto"
-        onClick={(e) => e.stopPropagation()}
-        role="document"
+        className="fixed inset-0 z-[70] flex items-center justify-center pointer-events-none"
       >
-        {/* Close button */}
-        <button
-          aria-label={t('tutorial.close')}
-          onClick={dismissTutorial}
-          className="absolute top-3 right-3 w-8 h-8 flex items-center justify-center rounded-full text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition text-lg"
-        >
-          ✕
-        </button>
+        <div className="pointer-events-auto w-full max-w-md mx-4" onClick={(e) => e.stopPropagation()}>
+          <ModalFrame
+            isOpen
+            onClose={dismissTutorial}
+            ariaLabel={t('tutorial.dialogLabel')}
+            title={translatedTitle}
+            headerIcon={step.icon}
+            variant="coachmark"
+            arrowDirection={arrowDirection}
+            disableEscClose
+          >
+            {/* Description */}
+            <div className="flex flex-col gap-4">
+              <p style={{ color: 'var(--color-stone-600)', lineHeight: 'var(--line-height-body)' }}>
+                {translatedDescription}
+              </p>
 
-        {/* Step icon + title */}
-        <div className="flex items-center gap-3">
-          {step.icon && (
-            <span className="text-3xl" aria-hidden="true">
-              {step.icon}
-            </span>
-          )}
-          <h2 className="text-xl font-bold text-gray-800">{translatedTitle}</h2>
-        </div>
+              {shouldShowActionHint && (
+                <p
+                  className="text-sm font-semibold rounded-lg px-3 py-2"
+                  style={{
+                    color: 'var(--color-player-blue)',
+                    backgroundColor: 'oklch(0.96 0.015 252)',
+                    border: '1px solid oklch(0.88 0.02 252)',
+                  }}
+                >
+                  {t('tutorial.performHighlightedAction')}
+                </p>
+              )}
 
-        {/* Description */}
-        <p className="text-gray-600 leading-relaxed">{translatedDescription}</p>
-
-        {shouldShowActionHint && (
-          <p className="text-sm font-semibold text-blue-700 bg-blue-50 border border-blue-100 rounded-lg px-3 py-2">
-            {t('tutorial.performHighlightedAction')}
-          </p>
-        )}
-
-        {/* Progress bar */}
-        <div className="w-full bg-gray-200 rounded-full h-1.5" aria-hidden="true">
-          <div
-            className="bg-blue-500 h-1.5 rounded-full transition-all duration-300"
-            style={{ width: `${progress}%` }}
-          />
-        </div>
-
-        {/* Step counter + navigation */}
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-gray-400">
-            {t('tutorial.stepCounter', { current: currentStepIndex + 1, total: TUTORIAL_STEPS.length })}
-          </span>
-
-          <div className="flex gap-2">
-            {!isFirstStep && (
-              <button
-                onClick={prevStep}
-                className="px-4 py-2 rounded-lg border border-gray-300 text-sm font-medium text-gray-600 hover:bg-gray-50 transition"
+              {/* Progress bar */}
+              <div
+                className="w-full rounded-full h-1.5"
+                style={{ backgroundColor: 'var(--progress-track)' }}
+                aria-hidden="true"
               >
-                {t('tutorial.back')}
-              </button>
-            )}
+                <div
+                  className="h-1.5 rounded-full transition-all duration-300"
+                  style={{ width: `${progress}%`, backgroundColor: 'var(--progress-fill)' }}
+                />
+              </div>
 
-            {isLastStep ? (
-              <button
-                onClick={completeTutorial}
-                className="px-5 py-2 rounded-lg bg-green-600 hover:bg-green-700 text-white text-sm font-semibold transition"
-              >
-                {t('tutorial.finish')}
-              </button>
-            ) : (
-              <button
-                onClick={nextStep}
-                className="px-5 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold transition"
-              >
-                {t('tutorial.next')}
-              </button>
-            )}
-          </div>
+              {/* Step counter + navigation */}
+              <div className="flex items-center justify-between">
+                <span className="text-xs" style={{ color: 'var(--color-stone-400)' }}>
+                  {t('tutorial.stepCounter', { current: currentStepIndex + 1, total: TUTORIAL_STEPS.length })}
+                </span>
+
+                <div className="flex gap-2">
+                  {!isFirstStep && (
+                    <button
+                      onClick={prevStep}
+                      className="px-4 py-2 rounded-lg text-sm font-medium transition"
+                      style={{
+                        border: '1px solid var(--card-border)',
+                        color: 'var(--color-stone-600)',
+                        backgroundColor: 'transparent',
+                      }}
+                    >
+                      {t('tutorial.back')}
+                    </button>
+                  )}
+
+                  {isLastStep ? (
+                    <button
+                      onClick={completeTutorial}
+                      className="px-5 py-2 rounded-lg text-sm font-semibold transition"
+                      style={{
+                        backgroundColor: 'var(--color-ink-green-600)',
+                        color: 'var(--button-text)',
+                      }}
+                    >
+                      {t('tutorial.finish')}
+                    </button>
+                  ) : (
+                    <button
+                      onClick={nextStep}
+                      className="px-5 py-2 rounded-lg text-sm font-semibold transition"
+                      style={{
+                        backgroundColor: 'var(--button-primary-bg)',
+                        color: 'var(--button-text)',
+                      }}
+                    >
+                      {t('tutorial.next')}
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              {/* Keyboard hint */}
+              <p className="text-xs text-center" style={{ color: 'var(--color-stone-400)' }}>
+                {t('tutorial.keyboardHint')}
+              </p>
+            </div>
+          </ModalFrame>
         </div>
-
-        {/* Keyboard hint */}
-        <p className="text-xs text-gray-400 text-center">
-          {t('tutorial.keyboardHint')}
-        </p>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/UI/ModalFrame.tsx
+++ b/src/components/UI/ModalFrame.tsx
@@ -1,0 +1,266 @@
+/**
+ * ModalFrame — shared modal chrome for Kingdom Builder Web
+ *
+ * Visual spec:
+ *  - 4px wine-600 primary accent rail on panel left edge
+ *  - Header: optional icon + optional kicker + title + CloseIcon button
+ *  - Scrollable body (overflow-y-auto)
+ *  - Optional footer slot (primary + ghost button pattern)
+ *  - Backdrop: bg-black/70 backdrop-blur-sm
+ *  - Enter animation: animate-modal-enter (160ms ease-out, defined in animations.css)
+ *  - Mobile (<= 640px): bottom-sheet (fixed inset-x-0 bottom-0, rounded-t-[--radius-20], max-h-[90vh])
+ *
+ * z-index layers:
+ *  - backdrop: z-[50]
+ *  - modal panel: z-[51]
+ *  - coachmark variant: z-[70]  (TutorialOverlay)
+ *  - toast: z-[80]              (AchievementToast — unchanged)
+ *
+ * Variant "coachmark":
+ *  - No backdrop rendered (TutorialOverlay renders its own)
+ *  - No 4px rail
+ *  - Higher z-index (z-[70])
+ *  - Arrow pointer rendered via CSS triangle based on spotlightRect position
+ */
+
+import React from 'react';
+import { CloseIcon } from '../icons/CloseIcon';
+import { useModal } from '../../hooks/useModal';
+
+export type ModalVariant = 'default' | 'coachmark';
+
+export interface ArrowDirection {
+  side: 'top' | 'bottom' | 'left' | 'right';
+  offsetPct?: number; // 0-100, percentage offset along the chosen axis
+}
+
+export interface ModalFrameProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Accessible label for the dialog (aria-label) */
+  ariaLabel: string;
+
+  // Header
+  title: React.ReactNode;
+  /** Small text above title (--type-label size) */
+  kicker?: React.ReactNode;
+  /** Icon element displayed left of title */
+  headerIcon?: React.ReactNode;
+
+  // Slots
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+
+  // Behaviour
+  variant?: ModalVariant;
+  /** When variant="coachmark", direction of the arrow pointer */
+  arrowDirection?: ArrowDirection;
+  /** When true, ESC key will not call onClose (TutorialOverlay manages its own ESC) */
+  disableEscClose?: boolean;
+
+  /** Additional className for the panel */
+  className?: string;
+}
+
+function ArrowPointer({ direction }: { direction: ArrowDirection }) {
+  const { side, offsetPct = 50 } = direction;
+
+  const isHorizontal = side === 'top' || side === 'bottom';
+  const arrowSize = 10;
+
+  const style: React.CSSProperties = {
+    position: 'absolute',
+    width: 0,
+    height: 0,
+    zIndex: 1,
+  };
+
+  if (side === 'top') {
+    style.top = -arrowSize;
+    style.left = `${offsetPct}%`;
+    style.transform = 'translateX(-50%)';
+    style.borderLeft = `${arrowSize}px solid transparent`;
+    style.borderRight = `${arrowSize}px solid transparent`;
+    style.borderBottom = `${arrowSize}px solid var(--color-surface)`;
+  } else if (side === 'bottom') {
+    style.bottom = -arrowSize;
+    style.left = `${offsetPct}%`;
+    style.transform = 'translateX(-50%)';
+    style.borderLeft = `${arrowSize}px solid transparent`;
+    style.borderRight = `${arrowSize}px solid transparent`;
+    style.borderTop = `${arrowSize}px solid var(--color-surface)`;
+  } else if (side === 'left') {
+    style.left = -arrowSize;
+    style.top = `${offsetPct}%`;
+    style.transform = 'translateY(-50%)';
+    style.borderTop = `${arrowSize}px solid transparent`;
+    style.borderBottom = `${arrowSize}px solid transparent`;
+    style.borderRight = `${arrowSize}px solid var(--color-surface)`;
+  } else {
+    // right
+    style.right = -arrowSize;
+    style.top = `${offsetPct}%`;
+    style.transform = 'translateY(-50%)';
+    style.borderTop = `${arrowSize}px solid transparent`;
+    style.borderBottom = `${arrowSize}px solid transparent`;
+    style.borderLeft = `${arrowSize}px solid var(--color-surface)`;
+  }
+
+  // Keep linter happy — isHorizontal might be used for future logic
+  void isHorizontal;
+
+  return <div aria-hidden="true" style={style} />;
+}
+
+export const ModalFrame = React.memo(function ModalFrame({
+  isOpen,
+  onClose,
+  ariaLabel,
+  title,
+  kicker,
+  headerIcon,
+  children,
+  footer,
+  variant = 'default',
+  arrowDirection,
+  disableEscClose = false,
+  className = '',
+}: ModalFrameProps) {
+  const { panelRef, handleBackdropClick } = useModal({ isOpen, onClose, disableEscClose });
+
+  if (!isOpen) return null;
+
+  const isCoachmark = variant === 'coachmark';
+
+  // Backdrop is NOT rendered for coachmark (TutorialOverlay provides its own dimming layer)
+  const backdropClasses = isCoachmark
+    ? null
+    : 'fixed inset-0 bg-black/70 backdrop-blur-sm z-[50] flex items-center justify-center px-4';
+
+  // Panel positioning
+  // Default: centred dialog
+  // Mobile (sm breakpoint ≤ 640px): bottom-sheet
+  const panelBaseDesktop = 'relative bg-[var(--color-surface)] rounded-[var(--radius-14)] shadow-[var(--shadow-lifted)] overflow-hidden flex flex-col w-full max-w-2xl max-h-[85vh]';
+  const panelBaseMobile = 'max-sm:fixed max-sm:inset-x-0 max-sm:bottom-0 max-sm:rounded-t-[var(--radius-20)] max-sm:rounded-bl-none max-sm:rounded-br-none max-sm:max-h-[90vh] max-sm:max-w-none';
+
+  const panelCoachmark = 'relative bg-[var(--color-surface)] rounded-[var(--radius-14)] shadow-[var(--shadow-lifted)] overflow-hidden flex flex-col w-full max-w-md';
+
+  const panelClasses = isCoachmark
+    ? panelCoachmark
+    : `${panelBaseDesktop} ${panelBaseMobile}`;
+
+  const zPanel = isCoachmark ? 'z-[70]' : 'z-[51]';
+
+  const panel = (
+    <div
+      ref={panelRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label={ariaLabel}
+      className={`${panelClasses} ${zPanel} animate-modal-enter ${className}`}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {/* 4px primary accent rail — default variant only */}
+      {!isCoachmark && (
+        <div
+          aria-hidden="true"
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            bottom: 0,
+            width: 4,
+            backgroundColor: 'var(--color-wine-600)',
+            borderTopLeftRadius: 'var(--radius-14)',
+            borderBottomLeftRadius: 'var(--radius-14)',
+          }}
+        />
+      )}
+
+      {/* Arrow pointer — coachmark variant */}
+      {isCoachmark && arrowDirection && (
+        <ArrowPointer direction={arrowDirection} />
+      )}
+
+      {/* Header */}
+      <div
+        className="flex items-start justify-between gap-3 px-6 py-4 shrink-0"
+        style={{
+          paddingLeft: isCoachmark ? undefined : '1.75rem', // 4px rail + normal padding
+          borderBottom: '1px solid var(--card-border)',
+        }}
+      >
+        <div className="flex items-center gap-3 min-w-0">
+          {headerIcon && (
+            <span className="text-2xl shrink-0" aria-hidden="true">
+              {headerIcon}
+            </span>
+          )}
+          <div className="min-w-0">
+            {kicker && (
+              <p
+                className="font-semibold uppercase tracking-wider"
+                style={{
+                  fontSize: 'var(--type-label)',
+                  color: 'var(--color-stone-500)',
+                  lineHeight: 'var(--line-height-label)',
+                }}
+              >
+                {kicker}
+              </p>
+            )}
+            <h2
+              className="font-bold truncate"
+              style={{
+                fontFamily: 'var(--font-display)',
+                fontSize: 'var(--type-display-sm)',
+                lineHeight: 'var(--line-height-display)',
+                color: 'var(--color-text)',
+              }}
+            >
+              {title}
+            </h2>
+          </div>
+        </div>
+
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="shrink-0 flex items-center justify-center w-8 h-8 rounded-full transition"
+          style={{ color: 'var(--color-stone-500)' }}
+        >
+          <CloseIcon size={18} />
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto px-6 py-4" style={{ paddingLeft: isCoachmark ? undefined : '1.75rem' }}>
+        {children}
+      </div>
+
+      {/* Footer (optional) */}
+      {footer && (
+        <div
+          className="shrink-0 flex items-center justify-end gap-3 px-6 py-4"
+          style={{
+            paddingLeft: isCoachmark ? undefined : '1.75rem',
+            borderTop: '1px solid var(--card-border)',
+          }}
+        >
+          {footer}
+        </div>
+      )}
+    </div>
+  );
+
+  if (isCoachmark) {
+    // No backdrop wrapper — render panel directly
+    return panel;
+  }
+
+  return (
+    <div className={backdropClasses!} onClick={handleBackdropClick}>
+      {panel}
+    </div>
+  );
+});

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,109 @@
+import { useEffect, useRef, useCallback } from 'react';
+
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+interface UseModalOptions {
+  isOpen: boolean;
+  onClose: () => void;
+  /** If true, ESC key will NOT call onClose (e.g. TutorialOverlay manages its own ESC) */
+  disableEscClose?: boolean;
+}
+
+/**
+ * Provides ESC-to-close, backdrop-click-to-close, focus trap, and body scroll lock for modal dialogs.
+ *
+ * Returns:
+ *  - `panelRef` – attach to the modal panel element for focus trap
+ *  - `handleBackdropClick` – pass to the backdrop onClick
+ */
+export function useModal({ isOpen, onClose, disableEscClose = false }: UseModalOptions) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  // Stable reference so event listener can always call the latest onClose
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  // ESC key handler
+  useEffect(() => {
+    if (!isOpen || disableEscClose) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCloseRef.current();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, disableEscClose]);
+
+  // Focus trap
+  useEffect(() => {
+    if (!isOpen || !panelRef.current) return;
+
+    const panel = panelRef.current;
+
+    // Move focus into the panel on open
+    const firstFocusable = panel.querySelector<HTMLElement>(FOCUSABLE_SELECTORS);
+    firstFocusable?.focus();
+
+    const handleTabTrap = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+
+      const focusable = Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)).filter(
+        (el) => !el.closest('[hidden]') && el.offsetParent !== null
+      );
+
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    panel.addEventListener('keydown', handleTabTrap);
+    return () => panel.removeEventListener('keydown', handleTabTrap);
+  }, [isOpen]);
+
+  // Body scroll lock
+  useEffect(() => {
+    if (!isOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [isOpen]);
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) {
+        onCloseRef.current();
+      }
+    },
+    []
+  );
+
+  return { panelRef, handleBackdropClick };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "./styles/tokens.css";
+@import "./styles/animations.css";
 
 body {
   margin: 0;

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -151,6 +151,24 @@
 }
 
 /* ----------------------------------------------------------
+ * Modal enter (opacity 0→1 + scale 0.96→1.0, 160 ms)
+ * ---------------------------------------------------------- */
+@keyframes modalEnter {
+  0% {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.animate-modal-enter {
+  animation: modalEnter 160ms ease-out both;
+}
+
+/* ----------------------------------------------------------
  * Accessibility: disable all animations when user prefers
  * reduced motion (WCAG 2.1 Success Criterion 2.3.3)
  * ---------------------------------------------------------- */


### PR DESCRIPTION
## 摘要

Closes #110

建立共用 `ModalFrame` 元件與 `useModal` hook，重構四套既有 modal 元件共用相同框架。

### 變更清單

- **新增** `src/components/UI/ModalFrame.tsx` — 共用 modal chrome
  - 4px wine-600 primary accent rail（panel 左緣）
  - Header：icon(optional) + kicker(optional) + title(--font-display) + CloseIcon
  - scrollable body + footer slot（optional）
  - Backdrop：bg-black/70 backdrop-blur-sm
  - `variant="default"` 置中 dialog；mobile(≤640px) 自動切 bottom-sheet
  - `variant="coachmark"` 無 rail、有 arrow pointer、z-[70]（供 TutorialOverlay）
  - z-index：backdrop=50 / modal=51 / coachmark=70（不衝突 BottomDrawer z-20/30、TurnBanner z-20）

- **新增** `src/hooks/useModal.ts`
  - ESC keydown → onClose（`disableEscClose` 旗標可停用）
  - backdrop click → onClose
  - focus trap（Tab 循環在 modal 內）
  - body scroll lock（isOpen 時）

- **修改** `src/styles/animations.css` — 加入 `modal-enter` keyframe（opacity 0→1 + scale 0.96→1.0，160ms ease-out）+ prefers-reduced-motion 覆蓋

- **修改** `src/index.css` — 補 `@import "./styles/animations.css"`

- **重構** `LeaderboardModal.tsx` / `AchievementPanel.tsx` / `ReplayModal.tsx` — 改用 ModalFrame

- **重構** `TutorialOverlay.tsx` — 使用 `variant="coachmark"`，保留 spotlight rect 計算邏輯完全不動，ESC → dismissTutorial 保留在元件內部

### 截圖路徑

- `/tmp/cto-a-110-desktop1440-leaderboard.png`
- `/tmp/cto-a-110-desktop1440-tutorial-coachmark.png`
- `/tmp/cto-a-110-mobile375-leaderboard-bottomsheet.png`
- `/tmp/cto-a-110-mobile375-achievement-bottomsheet.png`
- `/tmp/cto-a-110-focus-trap.png`

## DoD 勾選

- [x] `npx tsc --noEmit` → 0 errors
- [x] `npx vitest run` → 338 tests passed, 27 files, 0 new failures
- [x] `npx vite build` → 成功（436KB JS, 41KB CSS）
- [x] 5 張截圖：desktop Leaderboard / Tutorial coachmark / mobile Leaderboard bottom-sheet / mobile Achievement bottom-sheet / focus trap
- [x] commit + push origin feat/110-modal-frame
- [x] PR 開啟，Closes #110，指定 reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)