### PR TITLE
feat(map-editor): #99 Phase 1 — 資料層 codec + customMapStore + 測試

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -35,3 +35,4 @@ createRoot(document.getElementById('root')!).render(
 )
 
 registerSW()
+import './mapEditor/devExpose'

--- a/src/mapEditor/codec.test.ts
+++ b/src/mapEditor/codec.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { encode, decode } from './codec';
+import { Terrain, Location } from '../core/terrain';
+import { CustomMapPayload } from './types';
+
+const samplePayload: CustomMapPayload = {
+  v: 1,
+  w: 12,
+  h: 12,
+  cells: [
+    { q: 0, r: 0, terrain: Terrain.Grass },
+    { q: 1, r: 0, terrain: Terrain.Forest, location: Location.Castle },
+  ],
+};
+
+const emptyPayload: CustomMapPayload = {
+  v: 1,
+  w: 16,
+  h: 16,
+  cells: [],
+};
+
+describe('encode', () => {
+  it('should produce a string starting with KB-v1-', () => {
+    const code = encode(samplePayload);
+    expect(code).toMatch(/^KB-v1-/);
+  });
+
+  it('should produce only valid Base64 chars after prefix', () => {
+    const code = encode(samplePayload);
+    const b64 = code.slice('KB-v1-'.length);
+    expect(b64).toMatch(/^[A-Za-z0-9+/=]+$/);
+  });
+
+  it('empty cells round-trip should produce valid prefix', () => {
+    const code = encode(emptyPayload);
+    expect(code).toMatch(/^KB-v1-/);
+  });
+});
+
+describe('decode — happy path', () => {
+  it('should round-trip samplePayload', () => {
+    const code = encode(samplePayload);
+    const result = decode(code);
+    expect(result).toEqual(samplePayload);
+  });
+
+  it('should round-trip emptyPayload', () => {
+    const code = encode(emptyPayload);
+    const result = decode(code);
+    expect(result).toEqual(emptyPayload);
+  });
+});
+
+describe('decode — security guards', () => {
+  it('empty string → null', () => {
+    expect(decode('')).toBeNull();
+  });
+
+  it('wrong prefix KB-v2- → null', () => {
+    const code = encode(samplePayload).replace('KB-v1-', 'KB-v2-');
+    expect(decode(code)).toBeNull();
+  });
+
+  it('exceeds 50000 char limit → null', () => {
+    const longCode = 'KB-v1-' + 'A'.repeat(50001);
+    expect(decode(longCode)).toBeNull();
+  });
+
+  it('valid Base64 but not JSON → null', () => {
+    const notJson = 'KB-v1-' + btoa('this is not json');
+    expect(decode(notJson)).toBeNull();
+  });
+
+  it('v !== 1 → null', () => {
+    const bad = { ...samplePayload, v: 2 };
+    const json = JSON.stringify(bad);
+    const bytes = new TextEncoder().encode(json);
+    const binary = String.fromCharCode(...bytes);
+    const code = 'KB-v1-' + btoa(binary);
+    expect(decode(code)).toBeNull();
+  });
+
+  it('w not in [12,16,20] → null', () => {
+    const bad = { ...samplePayload, w: 10 };
+    const json = JSON.stringify(bad);
+    const bytes = new TextEncoder().encode(json);
+    const binary = String.fromCharCode(...bytes);
+    const code = 'KB-v1-' + btoa(binary);
+    expect(decode(code)).toBeNull();
+  });
+
+  it('invalid terrain → null', () => {
+    const bad: any = {
+      v: 1,
+      w: 12,
+      h: 12,
+      cells: [{ q: 0, r: 0, terrain: 'InvalidTerrain' }],
+    };
+    const json = JSON.stringify(bad);
+    const bytes = new TextEncoder().encode(json);
+    const binary = String.fromCharCode(...bytes);
+    const code = 'KB-v1-' + btoa(binary);
+    expect(decode(code)).toBeNull();
+  });
+
+  it('invalid location → null', () => {
+    const bad: any = {
+      v: 1,
+      w: 12,
+      h: 12,
+      cells: [{ q: 0, r: 0, terrain: Terrain.Grass, location: 'NotALocation' }],
+    };
+    const json = JSON.stringify(bad);
+    const bytes = new TextEncoder().encode(json);
+    const binary = String.fromCharCode(...bytes);
+    const code = 'KB-v1-' + btoa(binary);
+    expect(decode(code)).toBeNull();
+  });
+
+  it('cells not array → null', () => {
+    const bad: any = { v: 1, w: 12, h: 12, cells: 'not-array' };
+    const json = JSON.stringify(bad);
+    const bytes = new TextEncoder().encode(json);
+    const binary = String.fromCharCode(...bytes);
+    const code = 'KB-v1-' + btoa(binary);
+    expect(decode(code)).toBeNull();
+  });
+
+  it('null as any → null (no throw)', () => {
+    expect(() => decode(null as any)).not.toThrow();
+    expect(decode(null as any)).toBeNull();
+  });
+});

--- a/src/mapEditor/codec.ts
+++ b/src/mapEditor/codec.ts
@@ -1,0 +1,61 @@
+import { Terrain, Location } from '../core/terrain';
+import { CustomMapPayload } from './types';
+
+const PREFIX = 'KB-v1-';
+const MAX_B64_LENGTH = 50000;
+const VALID_SIZES = [12, 16, 20];
+const B64_REGEX = /^[A-Za-z0-9+/=]+$/;
+
+export function encode(payload: CustomMapPayload): string {
+  const json = JSON.stringify(payload);
+  const bytes = new TextEncoder().encode(json);
+  const binary = String.fromCharCode(...bytes);
+  return PREFIX + btoa(binary);
+}
+
+export function decode(shareCode: unknown): CustomMapPayload | null {
+  try {
+    // 1. type check
+    if (typeof shareCode !== 'string') return null;
+
+    // 2. prefix check
+    if (!shareCode.startsWith(PREFIX)) return null;
+
+    const b64 = shareCode.slice(PREFIX.length);
+
+    // 3. size check BEFORE JSON.parse (DoS防禦)
+    if (b64.length > MAX_B64_LENGTH) return null;
+
+    // 4. whitelist regex check
+    if (!B64_REGEX.test(b64)) return null;
+
+    // 5. decode
+    const binary = atob(b64);
+    const bytes = Uint8Array.from(binary, c => c.charCodeAt(0));
+    const json = new TextDecoder().decode(bytes);
+    const parsed = JSON.parse(json);
+
+    // 6. schema validation
+    const { v, w, h, cells } = parsed;
+
+    if (v !== 1) return null;
+    if (!VALID_SIZES.includes(w)) return null;
+    if (!VALID_SIZES.includes(h)) return null;
+    if (!Array.isArray(cells)) return null;
+
+    const validTerrains = new Set(Object.values(Terrain));
+    const validLocations = new Set(Object.values(Location));
+
+    for (const cell of cells) {
+      if (typeof cell.q !== 'number') return null;
+      if (typeof cell.r !== 'number') return null;
+      if (!validTerrains.has(cell.terrain)) return null;
+      if (cell.location !== undefined && !validLocations.has(cell.location)) return null;
+    }
+
+    // 7. pass
+    return parsed as CustomMapPayload;
+  } catch {
+    return null;
+  }
+}

--- a/src/mapEditor/customMapStore.test.ts
+++ b/src/mapEditor/customMapStore.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCustomMapStore } from './customMapStore';
+import { encode } from './codec';
+import { Terrain } from '../core/terrain';
+import { CustomMapPayload } from './types';
+
+const samplePayload: CustomMapPayload = {
+  v: 1,
+  w: 12,
+  h: 12,
+  cells: [{ q: 0, r: 0, terrain: Terrain.Grass }],
+};
+
+function resetStore() {
+  localStorage.clear();
+  useCustomMapStore.setState({ maps: [] });
+}
+
+describe('customMapStore', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  describe('addMap', () => {
+    it('should add one map and return the record', () => {
+      const result = useCustomMapStore.getState().addMap('My Map', samplePayload);
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe('My Map');
+      expect(useCustomMapStore.getState().maps).toHaveLength(1);
+    });
+
+    it('should return null when adding the 11th map (limit 10)', () => {
+      const store = useCustomMapStore.getState();
+      for (let i = 0; i < 10; i++) {
+        store.addMap(`Map ${i}`, samplePayload);
+      }
+      const result = useCustomMapStore.getState().addMap('Map 11', samplePayload);
+      expect(result).toBeNull();
+      expect(useCustomMapStore.getState().maps).toHaveLength(10);
+    });
+  });
+
+  describe('deleteMap', () => {
+    it('should reduce count by 1 when deleting existing map', () => {
+      const store = useCustomMapStore.getState();
+      const record = store.addMap('To Delete', samplePayload);
+      expect(useCustomMapStore.getState().maps).toHaveLength(1);
+      useCustomMapStore.getState().deleteMap(record!.id);
+      expect(useCustomMapStore.getState().maps).toHaveLength(0);
+    });
+
+    it('should not throw when deleting non-existent id', () => {
+      expect(() => useCustomMapStore.getState().deleteMap('non-existent-id')).not.toThrow();
+    });
+  });
+
+  describe('importFromShareCode', () => {
+    it('should add a map when valid share code provided', () => {
+      const code = encode(samplePayload);
+      const result = useCustomMapStore.getState().importFromShareCode(code);
+      expect(result).not.toBeNull();
+      expect(useCustomMapStore.getState().maps).toHaveLength(1);
+    });
+
+    it('should return null and not change maps for invalid code', () => {
+      const result = useCustomMapStore.getState().importFromShareCode('INVALID_CODE');
+      expect(result).toBeNull();
+      expect(useCustomMapStore.getState().maps).toHaveLength(0);
+    });
+  });
+
+  describe('exportShareCode', () => {
+    it('should return string with KB-v1- prefix for existing map', () => {
+      const record = useCustomMapStore.getState().addMap('Export Me', samplePayload);
+      const code = useCustomMapStore.getState().exportShareCode(record!.id);
+      expect(code).not.toBeNull();
+      expect(code!).toMatch(/^KB-v1-/);
+    });
+
+    it('should return null for non-existent id', () => {
+      const code = useCustomMapStore.getState().exportShareCode('no-such-id');
+      expect(code).toBeNull();
+    });
+  });
+
+  describe('persistence', () => {
+    it('should write to localStorage after addMap', () => {
+      useCustomMapStore.getState().addMap('Persist Test', samplePayload);
+      const raw = localStorage.getItem('kingdom-custom-maps');
+      expect(raw).not.toBeNull();
+      const parsed = JSON.parse(raw!);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(1);
+    });
+
+    it('_loadFromStorage should rebuild maps from localStorage', () => {
+      useCustomMapStore.getState().addMap('Load Test', samplePayload);
+      // Reset in-memory state only
+      useCustomMapStore.setState({ maps: [] });
+      expect(useCustomMapStore.getState().maps).toHaveLength(0);
+      // Reload from storage
+      useCustomMapStore.getState()._loadFromStorage();
+      expect(useCustomMapStore.getState().maps).toHaveLength(1);
+      expect(useCustomMapStore.getState().maps[0].name).toBe('Load Test');
+    });
+
+    it('bad JSON in localStorage should produce empty maps without throwing', () => {
+      localStorage.setItem('kingdom-custom-maps', 'NOT_VALID_JSON{{{');
+      expect(() => useCustomMapStore.getState()._loadFromStorage()).not.toThrow();
+      expect(useCustomMapStore.getState().maps).toHaveLength(0);
+    });
+  });
+});

--- a/src/mapEditor/customMapStore.ts
+++ b/src/mapEditor/customMapStore.ts
@@ -1,0 +1,96 @@
+import { create } from 'zustand';
+import { CustomMapRecord, CustomMapPayload } from './types';
+import { encode, decode } from './codec';
+
+const STORAGE_KEY = 'kingdom-custom-maps';
+const MAX_MAPS = 10;
+const MAX_NAME_LENGTH = 40;
+
+function generateId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+interface CustomMapState {
+  maps: CustomMapRecord[];
+  addMap: (name: string, payload: CustomMapPayload) => CustomMapRecord | null;
+  updateMapName: (id: string, name: string) => void;
+  deleteMap: (id: string) => void;
+  getMap: (id: string) => CustomMapRecord | undefined;
+  importFromShareCode: (code: string) => CustomMapRecord | null;
+  exportShareCode: (id: string) => string | null;
+  _loadFromStorage: () => void;
+  _persist: () => void;
+}
+
+export const useCustomMapStore = create<CustomMapState>((set, get) => ({
+  maps: [],
+
+  addMap(name: string, payload: CustomMapPayload): CustomMapRecord | null {
+    const { maps } = get();
+    if (maps.length >= MAX_MAPS) return null;
+
+    const record: CustomMapRecord = {
+      id: generateId(),
+      name: name.slice(0, MAX_NAME_LENGTH),
+      createdAt: new Date().toISOString(),
+      mapData: payload,
+    };
+
+    set({ maps: [...maps, record] });
+    get()._persist();
+    return record;
+  },
+
+  updateMapName(id: string, name: string): void {
+    set(state => ({
+      maps: state.maps.map(m =>
+        m.id === id ? { ...m, name: name.slice(0, MAX_NAME_LENGTH) } : m
+      ),
+    }));
+    get()._persist();
+  },
+
+  deleteMap(id: string): void {
+    set(state => ({ maps: state.maps.filter(m => m.id !== id) }));
+    get()._persist();
+  },
+
+  getMap(id: string): CustomMapRecord | undefined {
+    return get().maps.find(m => m.id === id);
+  },
+
+  importFromShareCode(code: string): CustomMapRecord | null {
+    const payload = decode(code);
+    if (payload === null) return null;
+    return get().addMap('Imported Map', payload);
+  },
+
+  exportShareCode(id: string): string | null {
+    const record = get().getMap(id);
+    if (!record) return null;
+    return encode(record.mapData);
+  },
+
+  _loadFromStorage(): void {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        set({ maps: parsed as CustomMapRecord[] });
+      }
+    } catch {
+      set({ maps: [] });
+    }
+  },
+
+  _persist(): void {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(get().maps));
+    } catch {
+      // silent
+    }
+  },
+}));
+
+useCustomMapStore.getState()._loadFromStorage();

--- a/src/mapEditor/devExpose.ts
+++ b/src/mapEditor/devExpose.ts
@@ -1,0 +1,6 @@
+import { encode, decode } from './codec';
+import { useCustomMapStore } from './customMapStore';
+
+if (import.meta.env.DEV) {
+  (window as any).__KB__ = { encode, decode, store: () => useCustomMapStore.getState() };
+}

--- a/src/mapEditor/types.ts
+++ b/src/mapEditor/types.ts
@@ -1,0 +1,22 @@
+import { Terrain, Location } from '../core/terrain';
+
+export interface CustomMapCell {
+  q: number;
+  r: number;
+  terrain: Terrain;
+  location?: Location;
+}
+
+export interface CustomMapPayload {
+  v: 1;
+  w: number;
+  h: number;
+  cells: CustomMapCell[];
+}
+
+export interface CustomMapRecord {
+  id: string;
+  name: string;
+  createdAt: string;
+  mapData: CustomMapPayload;
+}


### PR DESCRIPTION
Part of #99 (Phase 1/4)

## 新增檔案

| 檔案 | 說明 |
|------|------|
| `src/mapEditor/types.ts` | `CustomMapCell` / `CustomMapPayload` / `CustomMapRecord` 介面定義 |
| `src/mapEditor/codec.ts` | `encode` / `decode` 純函式，原生 btoa/atob + TextEncoder/TextDecoder |
| `src/mapEditor/customMapStore.ts` | Zustand store，MAX_MAPS=10，MAX_NAME_LENGTH=40，localStorage 持久化 |
| `src/mapEditor/devExpose.ts` | `window.__KB__` DEV guard（`import.meta.env.DEV` 包覆） |
| `src/mapEditor/codec.test.ts` | 15 tests：encode 前綴/Base64、decode happy path、9 security guards |
| `src/mapEditor/customMapStore.test.ts` | 11 tests：addMap/deleteMap/import/export/persistence |
| `src/main.tsx` | 末尾加一行 `import './mapEditor/devExpose'` |

## 安全防禦

- **Size check 在 JSON.parse 之前**：b64 長度 > 50000 直接 return null，防 DoS
- **Regex whitelist**：`/^[A-Za-z0-9+/=]+$/` 過濾非法 Base64 字元
- **Enum schema 驗證**：terrain 必須在 `Object.values(Terrain)`，location 若存在必須在 `Object.values(Location)`
- **全函式 try/catch**：任何異常（atob 失敗、JSON parse 失敗）一律 return null 不 throw

## DoD

- `npx tsc --noEmit` → 0 errors
- `npx vitest run src/mapEditor` → 26 passed (codec 15 + customMapStore 11)
- `npx vitest run` → 384 passed，31 test files，無回歸
- `npx vite build` → built in 650ms，success

## 不動現有程式碼

本 PR 未修改 `src/core/`、`src/store/gameStore`、`src/multiplayer/` 或任何現有元件，僅在 `main.tsx` 末尾加一行 import。