### PR TITLE
feat(map-editor): #99 Phase 4 — 整合遊戲流程（GameSetup 自訂地圖 + initGame opt-in customBoard）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { ObjectiveCardBadge } from './components/Game/ObjectiveCardBadge'
 import { LocationTileCard, LocationTileIcon } from './components/Game/LocationTileCard'
 import { GamePhase } from './types'
 import type { PlayerConfig, GameOptions } from './types'
+import type { Board } from './core/board'
 import { Location } from './core/terrain'
 import { scoreCastle, scoreObjectiveCard } from './core/scoring'
 import { initAudio, playSound, isMuted, setMuted, SoundType } from './utils/soundEngine'
@@ -143,8 +144,8 @@ function App() {
   // More menu (Header ⋯ button)
   const [moreMenuOpen, setMoreMenuOpen] = useState(false)
 
-  const handleStart = (configs: PlayerConfig[], options: GameOptions) => {
-    initGame(configs, options);
+  const handleStart = (configs: PlayerConfig[], options: GameOptions, customBoard?: Board) => {
+    initGame(configs, options, customBoard);
     setGameStarted(true);
   };
 

--- a/src/components/Game/GameSetup.tsx
+++ b/src/components/Game/GameSetup.tsx
@@ -1,10 +1,14 @@
 import { useState } from 'react';
 import { PlayerConfig, BotDifficulty, GameOptions, BoardSize } from '../../types';
+import { Board } from '../../core/board';
 import { useTutorialStore } from '../../store/tutorialStore';
 import { useTranslation } from 'react-i18next';
+import { useCustomMapStore } from '../../mapEditor/customMapStore';
+import { decode } from '../../mapEditor/codec';
+import { payloadToBoard } from '../../mapEditor/payloadToBoard';
 
 interface GameSetupProps {
-  onStart: (configs: PlayerConfig[], options: GameOptions) => void;
+  onStart: (configs: PlayerConfig[], options: GameOptions, customBoard?: Board) => void;
   onBack?: () => void;
 }
 
@@ -33,6 +37,15 @@ export function GameSetup({ onStart, onBack }: GameSetupProps) {
   );
   const [options, setOptions] = useState<GameOptions>(DEFAULT_OPTIONS);
 
+  // Custom map state
+  const [useCustomMap, setUseCustomMap] = useState(false);
+  const [customMapSource, setCustomMapSource] = useState<'store' | 'code'>('store');
+  const [selectedMapId, setSelectedMapId] = useState<string | null>(null);
+  const [shareCodeInput, setShareCodeInput] = useState('');
+  const [shareCodeError, setShareCodeError] = useState<string | null>(null);
+  // Resolved payload from share code (null until validated)
+  const [resolvedSharePayload, setResolvedSharePayload] = useState<ReturnType<typeof decode>>(null);
+
   const startTutorial = useTutorialStore((s) => s.startTutorial);
 
   const handlePlayerCountChange = (count: number) => {
@@ -56,8 +69,43 @@ export function GameSetup({ onStart, onBack }: GameSetupProps) {
     setOptions(prev => ({ ...prev, [key]: value }));
   };
 
+  const handleToggleCustomMap = (value: boolean) => {
+    setUseCustomMap(value);
+    // Clear custom map state when toggling off
+    if (!value) {
+      setSelectedMapId(null);
+      setShareCodeInput('');
+      setShareCodeError(null);
+      setResolvedSharePayload(null);
+    }
+  };
+
+  const handleValidateShareCode = () => {
+    const payload = decode(shareCodeInput.trim());
+    if (payload === null) {
+      setShareCodeError(t('setup.invalidShareCode'));
+      setResolvedSharePayload(null);
+    } else {
+      setShareCodeError(null);
+      setResolvedSharePayload(payload);
+    }
+  };
+
   const handleStart = () => {
-    onStart(configs, options);
+    if (useCustomMap) {
+      let customBoard: Board | undefined;
+      if (customMapSource === 'store' && selectedMapId) {
+        const record = useCustomMapStore.getState().getMap(selectedMapId);
+        if (record) {
+          customBoard = payloadToBoard(record.mapData);
+        }
+      } else if (customMapSource === 'code' && resolvedSharePayload) {
+        customBoard = payloadToBoard(resolvedSharePayload);
+      }
+      onStart(configs, options, customBoard);
+    } else {
+      onStart(configs, options);
+    }
   };
 
   const difficultyLabels: Record<BotDifficulty, string> = {
@@ -71,6 +119,8 @@ export function GameSetup({ onStart, onBack }: GameSetupProps) {
     medium: t('setup.boardSizeMedium'),
     large: t('setup.boardSizeLarge'),
   };
+
+  const savedMaps = useCustomMapStore.getState().maps;
 
   return (
     <div
@@ -217,29 +267,154 @@ export function GameSetup({ onStart, onBack }: GameSetupProps) {
           ))}
         </div>
 
-        {/* Board Size */}
+        {/* Use Custom Map toggle */}
         <div className="mb-5">
-          <label className="block text-body-sm font-body font-medium mb-2" style={{ color: 'var(--color-stone-700)' }}>
-            {t('setup.boardSize')}
-          </label>
-          <div className="flex gap-2">
-            {(['small', 'medium', 'large'] as BoardSize[]).map(size => (
-              <button
-                key={size}
-                onClick={() => updateOption('boardSize', size)}
-                aria-pressed={options.boardSize === size}
-                className="flex-1 py-2 rounded-12 text-body-sm font-body font-semibold transition"
-                style={
-                  options.boardSize === size
-                    ? { backgroundColor: 'var(--button-secondary-bg)', color: 'var(--button-text)', border: '2px solid var(--button-secondary-bg)' }
-                    : { backgroundColor: 'var(--color-warm-cream-100)', color: 'var(--color-stone-700)', border: '2px solid var(--card-border)' }
-                }
-              >
-                {boardSizeLabels[size]}
-              </button>
-            ))}
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-body-sm font-body font-medium" style={{ color: 'var(--color-stone-700)' }}>
+              {t('setup.useCustomMap')}
+            </span>
+            <button
+              role="switch"
+              aria-checked={useCustomMap}
+              aria-label={t('setup.useCustomMap')}
+              onClick={() => handleToggleCustomMap(!useCustomMap)}
+              className="relative inline-flex h-6 w-11 items-center rounded-full transition"
+              style={{ backgroundColor: useCustomMap ? 'var(--color-ink-green-500)' : 'var(--color-stone-300)' }}
+            >
+              <span
+                className="inline-block h-4 w-4 transform rounded-full bg-white transition"
+                style={{ transform: useCustomMap ? 'translateX(1.5rem)' : 'translateX(0.25rem)' }}
+              />
+            </button>
           </div>
+          <p className="text-label font-body" style={{ color: 'var(--color-stone-400)' }}>
+            {t('setup.customMapMultiplayerNote')}
+          </p>
         </div>
+
+        {/* Board Size (hidden when custom map is on) */}
+        {!useCustomMap && (
+          <div className="mb-5">
+            <label className="block text-body-sm font-body font-medium mb-2" style={{ color: 'var(--color-stone-700)' }}>
+              {t('setup.boardSize')}
+            </label>
+            <div className="flex gap-2">
+              {(['small', 'medium', 'large'] as BoardSize[]).map(size => (
+                <button
+                  key={size}
+                  onClick={() => updateOption('boardSize', size)}
+                  aria-pressed={options.boardSize === size}
+                  className="flex-1 py-2 rounded-12 text-body-sm font-body font-semibold transition"
+                  style={
+                    options.boardSize === size
+                      ? { backgroundColor: 'var(--button-secondary-bg)', color: 'var(--button-text)', border: '2px solid var(--button-secondary-bg)' }
+                      : { backgroundColor: 'var(--color-warm-cream-100)', color: 'var(--color-stone-700)', border: '2px solid var(--card-border)' }
+                  }
+                >
+                  {boardSizeLabels[size]}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Custom Map selector (shown when custom map is on) */}
+        {useCustomMap && (
+          <div
+            className="mb-5 rounded-12 p-4"
+            style={{ border: '1px solid var(--card-border)', backgroundColor: 'var(--color-warm-cream-50)' }}
+          >
+            {/* Source toggle */}
+            <div className="flex gap-2 mb-4">
+              {(['store', 'code'] as const).map(src => (
+                <button
+                  key={src}
+                  onClick={() => {
+                    setCustomMapSource(src);
+                    setShareCodeError(null);
+                  }}
+                  aria-pressed={customMapSource === src}
+                  className="flex-1 py-1 rounded-8 text-body-sm font-body font-medium transition"
+                  style={
+                    customMapSource === src
+                      ? { backgroundColor: 'var(--button-secondary-bg)', color: 'var(--button-text)', border: '2px solid var(--button-secondary-bg)' }
+                      : { backgroundColor: 'var(--color-warm-cream-100)', color: 'var(--color-stone-700)', border: '2px solid var(--card-border)' }
+                  }
+                >
+                  {src === 'store' ? t('setup.customMapFromStore') : t('setup.customMapFromCode')}
+                </button>
+              ))}
+            </div>
+
+            {/* From store: map list */}
+            {customMapSource === 'store' && (
+              savedMaps.length === 0 ? (
+                <p className="text-body-sm font-body" style={{ color: 'var(--color-stone-500)' }}>
+                  {t('setup.noCustomMaps')}
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {savedMaps.map(record => (
+                    <button
+                      key={record.id}
+                      onClick={() => setSelectedMapId(record.id)}
+                      aria-pressed={selectedMapId === record.id}
+                      className="w-full text-left px-3 py-2 rounded-8 text-body-sm font-body transition"
+                      style={
+                        selectedMapId === record.id
+                          ? { backgroundColor: 'var(--button-secondary-bg)', color: 'var(--button-text)', border: '2px solid var(--button-secondary-bg)' }
+                          : { backgroundColor: 'var(--color-warm-cream-100)', color: 'var(--color-stone-700)', border: '2px solid var(--card-border)' }
+                      }
+                    >
+                      {record.name}
+                    </button>
+                  ))}
+                </div>
+              )
+            )}
+
+            {/* From share code */}
+            {customMapSource === 'code' && (
+              <div>
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={shareCodeInput}
+                    onChange={e => {
+                      setShareCodeInput(e.target.value);
+                      setShareCodeError(null);
+                      setResolvedSharePayload(null);
+                    }}
+                    placeholder="KB-v1-..."
+                    className="flex-1 rounded-8 px-2 py-1 text-body-sm"
+                    style={{
+                      border: shareCodeError ? '1px solid var(--color-wine-600)' : '1px solid var(--card-border)',
+                      backgroundColor: 'var(--color-warm-cream-50)',
+                      color: 'var(--color-stone-800)',
+                    }}
+                  />
+                  <button
+                    onClick={handleValidateShareCode}
+                    className="px-3 py-1 rounded-8 text-body-sm font-body font-medium transition"
+                    style={{ backgroundColor: 'var(--button-secondary-bg)', color: 'var(--button-text)' }}
+                  >
+                    OK
+                  </button>
+                </div>
+                {shareCodeError && (
+                  <p className="mt-1 text-label font-body" style={{ color: 'var(--color-wine-600)' }}>
+                    {shareCodeError}
+                  </p>
+                )}
+                {resolvedSharePayload && !shareCodeError && (
+                  <p className="mt-1 text-label font-body" style={{ color: 'var(--color-ink-green-600)' }}>
+                    {resolvedSharePayload.w}x{resolvedSharePayload.h}
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Game Options */}
         <div

--- a/src/components/MapEditor/MapEditorPage.tsx
+++ b/src/components/MapEditor/MapEditorPage.tsx
@@ -11,6 +11,7 @@ import { ImportCodeModal } from './ImportCodeModal';
 import { createBlankBoard } from '../../mapEditor/editorBoard';
 import { useCustomMapStore } from '../../mapEditor/customMapStore';
 import { CustomMapPayload, CustomMapRecord } from '../../mapEditor/types';
+import { payloadToBoard } from '../../mapEditor/payloadToBoard';
 import { BoardSize } from '../../types/index';
 
 interface MapEditorPageProps {
@@ -95,11 +96,7 @@ export const MapEditorPage: React.FC<MapEditorPageProps> = ({ onBack }) => {
   };
 
   const handleLoadMap = (record: CustomMapRecord) => {
-    const b = new Board(record.mapData.w, record.mapData.h);
-    record.mapData.cells.forEach(c =>
-      b.setCell({ coord: { q: c.q, r: c.r }, terrain: c.terrain, location: c.location, settlement: undefined })
-    );
-    setBoard(b);
+    setBoard(payloadToBoard(record.mapData));
     setMapListOpen(false);
   };
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -191,6 +191,12 @@ export const en = {
     allowUndo: 'Allow Undo (once per turn)',
     tutorial: '📖 How to Play (Tutorial)',
     startGame: 'Start Game',
+    useCustomMap: 'Use Custom Map',
+    customMapFromStore: 'Choose from saved maps',
+    customMapFromCode: 'Paste share code',
+    noCustomMaps: 'No saved maps. Create one in Map Editor first.',
+    invalidShareCode: 'Invalid share code. Please check and try again.',
+    customMapMultiplayerNote: 'Custom maps are not supported in multiplayer mode.',
   },
   gameOver: {
     heading: '🏆 Game Over!',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -190,6 +190,12 @@ export const zhTW = {
     allowUndo: '允許復原（每回合一次）',
     tutorial: '📖 教學：如何遊玩',
     startGame: '開始遊戲',
+    useCustomMap: '使用自訂地圖',
+    customMapFromStore: '從已存地圖選擇',
+    customMapFromCode: '貼入分享碼',
+    noCustomMaps: '尚無已存地圖，請先至地圖編輯器建立',
+    invalidShareCode: '分享碼無效，請確認後重試',
+    customMapMultiplayerNote: '多人模式不支援自訂地圖',
   },
   gameOver: {
     heading: '🏆 遊戲結束！',

--- a/src/mapEditor/payloadToBoard.test.ts
+++ b/src/mapEditor/payloadToBoard.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { payloadToBoard } from './payloadToBoard';
+import { Terrain, Location } from '../core/terrain';
+import { CustomMapPayload } from './types';
+
+const samplePayload: CustomMapPayload = {
+  v: 1,
+  w: 12,
+  h: 12,
+  cells: [
+    { q: 0, r: 0, terrain: Terrain.Grass },
+    { q: 1, r: 0, terrain: Terrain.Desert, location: Location.Oasis },
+    { q: 0, r: 1, terrain: Terrain.Forest },
+  ],
+};
+
+describe('payloadToBoard', () => {
+  it('creates a Board with correct dimensions', () => {
+    const board = payloadToBoard(samplePayload);
+    expect(board.width).toBe(12);
+    expect(board.height).toBe(12);
+  });
+
+  it('sets cells with correct terrain', () => {
+    const board = payloadToBoard(samplePayload);
+    const cell = board.getCell({ q: 0, r: 0 });
+    expect(cell).toBeDefined();
+    expect(cell!.terrain).toBe(Terrain.Grass);
+  });
+
+  it('sets cells with correct location', () => {
+    const board = payloadToBoard(samplePayload);
+    const cell = board.getCell({ q: 1, r: 0 });
+    expect(cell).toBeDefined();
+    expect(cell!.terrain).toBe(Terrain.Desert);
+    expect(cell!.location).toBe(Location.Oasis);
+  });
+
+  it('always sets settlement to undefined', () => {
+    const board = payloadToBoard(samplePayload);
+    for (const cell of board.getAllCells()) {
+      expect(cell.settlement).toBeUndefined();
+    }
+  });
+
+  it('cell without location has undefined location', () => {
+    const board = payloadToBoard(samplePayload);
+    const cell = board.getCell({ q: 0, r: 1 });
+    expect(cell).toBeDefined();
+    expect(cell!.location).toBeUndefined();
+  });
+});

--- a/src/mapEditor/payloadToBoard.ts
+++ b/src/mapEditor/payloadToBoard.ts
@@ -1,0 +1,14 @@
+import { Board } from '../core/board';
+import { CustomMapPayload } from './types';
+
+/**
+ * Converts a CustomMapPayload into a Board instance.
+ * settlement is always set to undefined (map editor stores no settlements).
+ */
+export function payloadToBoard(payload: CustomMapPayload): Board {
+  const b = new Board(payload.w, payload.h);
+  payload.cells.forEach(c =>
+    b.setCell({ coord: { q: c.q, r: c.r }, terrain: c.terrain, location: c.location, settlement: undefined })
+  );
+  return b;
+}

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -60,7 +60,7 @@ interface GameState {
   /** Options chosen at setup time */
   gameOptions: GameOptions;
 
-  initGame: (configs: PlayerConfig[] | number, options?: GameOptions) => void;
+  initGame: (configs: PlayerConfig[] | number, options?: GameOptions, customBoard?: Board) => void;
   drawTerrainCard: () => void;
   placeSettlement: (coord: AxialCoord) => void;
   endTurn: () => void;
@@ -223,7 +223,7 @@ export const gameStore = create<GameState>((set, get) => ({
   gameOptions: { boardSize: 'large', objectiveCount: 3, enableUndo: true },
 
   // ── Init ────────────────────────────────────────────
-  initGame: (configs: PlayerConfig[] | number, options?: GameOptions) => {
+  initGame: (configs: PlayerConfig[] | number, options?: GameOptions, customBoard?: Board) => {
     _consecutiveEmptyTurns = 0;
     let playerConfigs: PlayerConfig[];
 
@@ -264,7 +264,7 @@ export const gameStore = create<GameState>((set, get) => ({
     }));
 
     set({
-      board: createBoardForSize(resolvedOptions.boardSize),
+      board: customBoard ?? createBoardForSize(resolvedOptions.boardSize),
       players,
       currentPlayerIndex: 0,
       phase: GamePhase.DrawCard,

--- a/src/test/gameStore.customBoard.test.ts
+++ b/src/test/gameStore.customBoard.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit tests for initGame opt-in customBoard parameter.
+ *
+ * Verifies:
+ *  - Without customBoard: board.width equals default size (large = 20)
+ *  - With customBoard Board(12,12): get().board === customBoard and width === 12
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useGameStore } from '../store/gameStore';
+import { Board } from '../core/board';
+
+beforeEach(() => {
+  // Reset store between tests
+  useGameStore.setState({ board: new Board(20, 20) });
+});
+
+describe('initGame opt-in customBoard', () => {
+  it('without customBoard uses default board size (large = 20)', () => {
+    useGameStore.getState().initGame(2, { boardSize: 'large', objectiveCount: 3, enableUndo: true });
+    expect(useGameStore.getState().board.width).toBe(20);
+  });
+
+  it('with customBoard Board(12,12) uses injected board instance', () => {
+    const customBoard = new Board(12, 12);
+    useGameStore.getState().initGame(2, { boardSize: 'large', objectiveCount: 3, enableUndo: true }, customBoard);
+    const state = useGameStore.getState();
+    expect(state.board).toBe(customBoard);
+    expect(state.board.width).toBe(12);
+  });
+
+  it('with customBoard does not affect other state fields', () => {
+    const customBoard = new Board(16, 16);
+    useGameStore.getState().initGame(2, { boardSize: 'large', objectiveCount: 2, enableUndo: false }, customBoard);
+    const state = useGameStore.getState();
+    // Players should still be initialised correctly
+    expect(state.players).toHaveLength(2);
+    // Deck should be populated
+    expect(state.deck.length).toBeGreaterThan(0);
+    // Turn number resets
+    expect(state.turnNumber).toBe(1);
+    // customBoard correctly injected
+    expect(state.board.width).toBe(16);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #99 — Phase 4/4，地圖編輯器大功能全交付。

- 新建 `payloadToBoard` util，統一 CustomMapPayload → Board 轉換邏輯
- `initGame` 加 optional 第三參數 `customBoard?: Board`（opt-in，5 個既有呼叫端零改）
- `GameSetup` 新增自訂地圖 toggle，支援從已存地圖選擇 / 貼入分享碼兩路徑
- `App.tsx handleStart` 透傳 `customBoard` 給 `initGame`
- i18n zh-TW + en 新增 6 個 setup keys

## initGame opt-in 說明

```diff
- initGame: (configs: PlayerConfig[] | number, options?: GameOptions) => void
+ initGame: (configs: PlayerConfig[] | number, options?: GameOptions, customBoard?: Board) => void
```

注入點：`board: customBoard ?? createBoardForSize(resolvedOptions.boardSize)`

未傳 customBoard → undefined → 100% 走原 createBoardForSize 路徑，隨機遊戲行為不變。

## 5 個呼叫端零改確認

| 檔案 | 呼叫方式 | 改動 |
|------|---------|------|
| `App.tsx:148` | `initGame(configs, options, customBoard)` | 新增透傳（正確） |
| `MultiplayerSetup.tsx:89` | `initGame(configs, options)` | 未改 |
| `gameStore.undo.test.ts:21,263,269` | `initGame(2)` | 未改 |
| `gameStore.undo.tileCopy.test.ts:21` | `initGame(2)` | 未改 |
| `gameStore.botTiles.test.ts:12` | `initGame(players, {...})` | 未改 |

## 已知限制（Phase 4 不修）

1. 多人模式不支援自訂地圖（MultiplayerSetup 維持原簽名，UI 有小字說明）
2. Replay 回放不還原自訂地圖（replay viewer 用隨機地圖）
3. 分享碼貼上不存入 customMapStore（只當場使用）
4. 自訂地圖無 Castle 時城堡計分恆 0（正常降級）

## DoD

- `npx tsc --noEmit` → 0 errors
- `npx vitest run` → 401/401 passed（含新增 gameStore.customBoard.test.ts 3 tests + payloadToBoard.test.ts 5 tests）
- `npx vite build` → success（467KB bundle）
- 5 個既有 initGame 呼叫端未加第三參數確認