### PR TITLE
fix(setup): #133 GameSetup 自訂地圖 getMap undefined 時顯示提示不靜默降級

### DIFF
--- a/src/components/Game/GameSetup.tsx
+++ b/src/components/Game/GameSetup.tsx
@@ -43,6 +43,7 @@ export function GameSetup({ onStart, onBack }: GameSetupProps) {
   const [selectedMapId, setSelectedMapId] = useState<string | null>(null);
   const [shareCodeInput, setShareCodeInput] = useState('');
   const [shareCodeError, setShareCodeError] = useState<string | null>(null);
+  const [storeMapError, setStoreMapError] = useState<string | null>(null);
   // Resolved payload from share code (null until validated)
   const [resolvedSharePayload, setResolvedSharePayload] = useState<ReturnType<typeof decode>>(null);
 
@@ -76,6 +77,7 @@ export function GameSetup({ onStart, onBack }: GameSetupProps) {
       setSelectedMapId(null);
       setShareCodeInput('');
       setShareCodeError(null);
+      setStoreMapError(null);
       setResolvedSharePayload(null);
     }
   };
@@ -98,6 +100,9 @@ export function GameSetup({ onStart, onBack }: GameSetupProps) {
         const record = useCustomMapStore.getState().getMap(selectedMapId);
         if (record) {
           customBoard = payloadToBoard(record.mapData);
+        } else {
+          setStoreMapError(t('setup.mapNotFound'));
+          return;
         }
       } else if (customMapSource === 'code' && resolvedSharePayload) {
         customBoard = payloadToBoard(resolvedSharePayload);
@@ -332,6 +337,7 @@ export function GameSetup({ onStart, onBack }: GameSetupProps) {
                   onClick={() => {
                     setCustomMapSource(src);
                     setShareCodeError(null);
+                    setStoreMapError(null);
                   }}
                   aria-pressed={customMapSource === src}
                   className="flex-1 py-1 rounded-8 text-body-sm font-body font-medium transition"
@@ -357,7 +363,7 @@ export function GameSetup({ onStart, onBack }: GameSetupProps) {
                   {savedMaps.map(record => (
                     <button
                       key={record.id}
-                      onClick={() => setSelectedMapId(record.id)}
+                      onClick={() => { setSelectedMapId(record.id); setStoreMapError(null); }}
                       aria-pressed={selectedMapId === record.id}
                       className="w-full text-left px-3 py-2 rounded-8 text-body-sm font-body transition"
                       style={
@@ -369,6 +375,11 @@ export function GameSetup({ onStart, onBack }: GameSetupProps) {
                       {record.name}
                     </button>
                   ))}
+                  {storeMapError && (
+                    <p className="mt-1 text-label font-body" style={{ color: 'var(--color-wine-600)' }}>
+                      {storeMapError}
+                    </p>
+                  )}
                 </div>
               )
             )}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -196,6 +196,7 @@ export const en = {
     customMapFromCode: 'Paste share code',
     noCustomMaps: 'No saved maps. Create one in Map Editor first.',
     invalidShareCode: 'Invalid share code. Please check and try again.',
+    mapNotFound: 'Map not found. Please select again.',
     customMapMultiplayerNote: 'Custom maps are not supported in multiplayer mode.',
   },
   gameOver: {

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -195,6 +195,7 @@ export const zhTW = {
     customMapFromCode: '貼入分享碼',
     noCustomMaps: '尚無已存地圖，請先至地圖編輯器建立',
     invalidShareCode: '分享碼無效，請確認後重試',
+    mapNotFound: '地圖不存在，請重新選擇',
     customMapMultiplayerNote: '多人模式不支援自訂地圖',
   },
   gameOver: {


### PR DESCRIPTION
## 問題

`GameSetup.tsx` handleStart store 路徑：`getMap(selectedMapId)` 回傳 undefined 時，`customBoard` 維持 undefined，仍呼叫 `onStart` → initGame fallback 隨機地圖，使用者無感知靜默降級。

## 修法

**3 檔改動：**

- `src/components/Game/GameSetup.tsx`：新增 `storeMapError` state；handleStart store 路徑加 guard（getMap undefined → setStoreMapError + early return，不呼叫 onStart）；store 清單底部顯示 error（wine-600 inline，與 shareCodeError 樣式一致）；切換 toggle / source / 重選地圖時 reset error
- `src/i18n/locales/en.ts`：setup 物件新增 `mapNotFound: 'Map not found. Please select again.'`
- `src/i18n/locales/zh-TW.ts`：同位置新增 `mapNotFound: '地圖不存在，請重新選擇'`

## DoD

- `npx tsc --noEmit` → 0 errors
- `npx vitest run` → 401 passed / 34 files
- `npx vite build` → built in 649ms

Closes #133