### PR TITLE
feat(board): #135 聚落渲染 圓點→玩家色小房子 SVG

### DIFF
--- a/src/components/Board/HexCell.tsx
+++ b/src/components/Board/HexCell.tsx
@@ -5,6 +5,7 @@ import { getTerrainColor } from '../../core/terrain';
 import '../../styles/animations.css';
 import { useTranslation } from 'react-i18next';
 import { tTerrain } from '../../i18n/formatters';
+import { SettlementMarker } from './SettlementMarker';
 
 interface HexCellProps {
   cell: HexCellType;
@@ -123,14 +124,11 @@ export const HexCell: React.FC<HexCellProps> = React.memo(({
 
       {/* Show settlement marker if present */}
       {cell.settlement !== undefined && playerColor && (
-        <circle
+        <SettlementMarker
           cx={corners[0].x - HEX_SIZE}
           cy={corners[0].y}
-          r={HEX_SIZE * 0.4}
-          fill={playerColor}
-          stroke="#000"
-          strokeWidth={2}
-          className={isRecentlyPlaced ? 'animate-settlement-drop' : undefined}
+          playerColor={playerColor}
+          isRecentlyPlaced={isRecentlyPlaced}
         />
       )}
     </g>

--- a/src/components/Board/SettlementMarker.tsx
+++ b/src/components/Board/SettlementMarker.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+interface SettlementMarkerProps {
+  cx: number;
+  cy: number;
+  playerColor: string;
+  isRecentlyPlaced?: boolean;
+}
+
+export const SettlementMarker: React.FC<SettlementMarkerProps> = ({
+  cx,
+  cy,
+  playerColor,
+  isRecentlyPlaced,
+}) => {
+  return (
+    <g
+      transform={`translate(${cx}, ${cy})`}
+      pointerEvents="none"
+      className={isRecentlyPlaced ? 'animate-settlement-drop' : undefined}
+    >
+      {/* Roof: isosceles triangle, apex pointing up */}
+      <polygon
+        points="-7,0 7,0 0,-9"
+        fill={playerColor}
+        stroke="#1a1a1a"
+        strokeWidth={1.5}
+      />
+      {/* Wall: rectangle below roof */}
+      <rect
+        x={-5.5}
+        y={0}
+        width={11}
+        height={8}
+        fill={playerColor}
+        stroke="#1a1a1a"
+        strokeWidth={1.5}
+      />
+      {/* Door: dark cutout centered at bottom of wall */}
+      <rect
+        x={-2}
+        y={3}
+        width={4}
+        height={5}
+        fill="#1a1a1a"
+      />
+    </g>
+  );
+};
+
+SettlementMarker.displayName = 'SettlementMarker';


### PR DESCRIPTION
## Closes #135

將 settlement 渲染從單一 `<circle>` 升級為有結構的小房子 SVG。

## 設計摘要

新增 `src/components/Board/SettlementMarker.tsx` 元件：

- **屋頂**：等腰三角 `polygon points="-7,0 7,0 0,-9"`，fill=playerColor，stroke=#1a1a1a strokeWidth=1.5
- **牆身**：`rect x=-5.5 y=0 width=11 height=8`，fill=playerColor，stroke=#1a1a1a strokeWidth=1.5
- **門**：`rect x=-2 y=3 width=4 height=5`，fill=#1a1a1a（深色開口效果）
- 整體 18×14px，HEX_SIZE=30 格內留足邊距

## 關鍵安全確認

- `pointerEvents="none"` 掛在最外層 `<g>`，SettlementMarker 不攔截 HexCell 的 onClick/onMouseEnter 事件
- 落下動畫：`animate-settlement-drop` class 掛在最外層 `<g>`，複用既有 animations.css keyframe
- playerColor 直接作 SVG attribute（不用 CSS var / Tailwind class，避免 Tailwind v4 SVG 坑）
- 未動 src/core/、gameStore、settlement 放置邏輯、pan/zoom

## DoD 驗證

- `npx tsc --noEmit` → 0 errors
- `npx vitest run` → 401 tests passed (34 files)
- `npx vite build` → dist 468kB，build success