### PR TITLE
feat(ui): #138 整體 polish — 落子光暈/陰影層次/得分跳動/回合過場

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,72 @@ import {
 
 const STATE_BROADCAST_DEBOUNCE_MS = 50;
 
+/**
+ * Lightweight hook that returns the value from the previous render.
+ * Used to detect score increases for the scorePopIn animation.
+ */
+function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T | undefined>(undefined);
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+}
+
+interface ScoreRowProps {
+  playerId: string;
+  playerName: string | undefined;
+  playerColor: string;
+  total: number;
+  isLeader: boolean;
+  summaryText: string;
+  pointsLabel: string;
+}
+
+/**
+ * Score row with pop animation when total increases.
+ * Using a component so usePrevious can be called per-player safely.
+ */
+function ScoreRow({ playerId, playerName, playerColor, total, isLeader, summaryText, pointsLabel }: ScoreRowProps) {
+  const prevTotal = usePrevious(total);
+  const increased = prevTotal !== undefined && total > prevTotal;
+
+  return (
+    <div
+      key={playerId}
+      className="rounded-lg p-2"
+      style={{
+        border: `2px solid ${isLeader ? 'var(--color-amber-400)' : 'var(--card-border)'}`,
+        backgroundColor: isLeader ? 'oklch(0.97 0.02 80)' : 'var(--color-warm-cream-50)',
+      }}
+    >
+      <div className="flex justify-between items-center text-sm font-medium">
+        <div className="flex items-center gap-1.5">
+          <div
+            className="w-3 h-3 rounded-full"
+            style={{ backgroundColor: playerColor }}
+            aria-hidden="true"
+          />
+          <span style={{ color: 'var(--color-text)' }}>{playerName}</span>
+          {isLeader && (
+            <span className="text-xs" title="Leading">★</span>
+          )}
+        </div>
+        <span
+          key={increased ? `${playerId}-${total}` : playerId}
+          className={increased ? 'animate-score-pop font-bold' : 'font-bold'}
+          style={{ color: isLeader ? 'var(--color-amber-700)' : 'var(--color-text)' }}
+        >
+          {total} {pointsLabel}
+        </span>
+      </div>
+      <p className="text-xs mt-0.5" style={{ color: 'var(--color-stone-400)' }}>
+        {summaryText}
+      </p>
+    </div>
+  );
+}
+
 function App() {
   const { t, i18n } = useTranslation();
   const [muted, setMutedState] = useState(isMuted);
@@ -584,6 +650,7 @@ function App() {
           {/* TurnBanner – sticky above the board */}
           {phase !== GamePhase.GameOver && (
             <TurnBanner
+              key={currentPlayer?.id}
               currentPlayer={currentPlayer}
               phase={phase}
               currentTerrainCard={currentTerrainCard}
@@ -596,7 +663,7 @@ function App() {
           )}
 
           {/* HexGrid */}
-          <div className="flex-1 relative overflow-hidden">
+          <div className="flex-1 relative overflow-hidden" style={{ boxShadow: 'var(--shadow-medium)' }}>
             {players.length > 0 && (
               <div className="w-full h-full" data-tutorial-target="hex-grid">
               <HexGrid
@@ -929,43 +996,23 @@ function App() {
                       const p = players.find(pl => pl.id === ps.playerId)
                       const total = ps.castle + ps.objectives.reduce((s, o) => s + o.score, 0)
                       const isLeader = total === maxLiveScore && total > 0
+                      const summaryText = t('app.castleScoreSummary', {
+                        castle: ps.castle,
+                        objectives: ps.objectives
+                          .map(o => t('app.objectiveScoreItem', { card: tObjective(t, o.card), score: o.score }))
+                          .join(' | '),
+                      })
                       return (
-                        <div
+                        <ScoreRow
                           key={ps.playerId}
-                          className="rounded-lg p-2"
-                          style={{
-                            border: `2px solid ${isLeader ? 'var(--color-amber-400)' : 'var(--card-border)'}`,
-                            backgroundColor: isLeader ? 'oklch(0.97 0.02 80)' : 'var(--color-warm-cream-50)',
-                          }}
-                        >
-                          <div className="flex justify-between items-center text-sm font-medium">
-                            <div className="flex items-center gap-1.5">
-                              <div
-                                className="w-3 h-3 rounded-full"
-                                style={{ backgroundColor: p?.color ?? '#ccc' }}
-                                aria-hidden="true"
-                              />
-                              <span style={{ color: 'var(--color-text)' }}>{p?.name}</span>
-                              {isLeader && (
-                                <span className="text-xs" title="Leading">★</span>
-                              )}
-                            </div>
-                            <span
-                              className="font-bold"
-                              style={{ color: isLeader ? 'var(--color-amber-700)' : 'var(--color-text)' }}
-                            >
-                              {total} {t('common.pointsShort')}
-                            </span>
-                          </div>
-                          <p className="text-xs mt-0.5" style={{ color: 'var(--color-stone-400)' }}>
-                            {t('app.castleScoreSummary', {
-                              castle: ps.castle,
-                              objectives: ps.objectives
-                                .map(o => t('app.objectiveScoreItem', { card: tObjective(t, o.card), score: o.score }))
-                                .join(' | '),
-                            })}
-                          </p>
-                        </div>
+                          playerId={ps.playerId}
+                          playerName={p?.name}
+                          playerColor={p?.color ?? '#ccc'}
+                          total={total}
+                          isLeader={isLeader}
+                          summaryText={summaryText}
+                          pointsLabel={t('common.pointsShort')}
+                        />
                       )
                     })}
                   </div>

--- a/src/components/Board/HexGrid.tsx
+++ b/src/components/Board/HexGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { Board } from '../../core/board';
 import { AxialCoord, hexEquals, HEX_SIZE, axialToPixel } from '../../core/hex';
 import { HexCell } from './HexCell';
@@ -120,6 +120,40 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
   const svgRef = useRef<SVGSVGElement>(null);
 
   const cells = board.getAllCells();
+
+  // ── UI-only: track the most recently placed settlement cell ────────────────
+  // We compare the set of settlement keys before/after board changes.
+  // No gameStore logic is touched — this is purely a render-layer effect.
+  const [recentlyPlacedKey, setRecentlyPlacedKey] = useState<string | null>(null);
+  const prevSettlementKeysRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    // Build current settlement key set (only cells that have a settlement)
+    const currentKeys = new Set<string>();
+    for (const cell of cells) {
+      if (cell.settlement !== undefined) {
+        currentKeys.add(`${cell.coord.q},${cell.coord.r}`);
+      }
+    }
+
+    // Find any newly added key
+    let newKey: string | null = null;
+    for (const key of currentKeys) {
+      if (!prevSettlementKeysRef.current.has(key)) {
+        newKey = key;
+        break;
+      }
+    }
+
+    prevSettlementKeysRef.current = currentKeys;
+
+    if (newKey) {
+      setRecentlyPlacedKey(newKey);
+      const timer = setTimeout(() => setRecentlyPlacedKey(null), 350);
+      return () => clearTimeout(timer);
+    }
+  }, [cells]);
+  // ──────────────────────────────────────────────────────────────────────────
 
   // Calculate SVG dimensions
   // For axial coords, max x = HEX_SIZE * (√3 * (width-1) + √3/2 * (height-1))
@@ -387,6 +421,7 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
 
                   const key = `${cell.coord.q},${cell.coord.r}`;
                   const isEntry = entryCoord !== null && hexEquals(cell.coord, entryCoord);
+                  const isRecentlyPlaced = recentlyPlacedKey === key;
 
                   return (
                     <HexCell
@@ -395,6 +430,7 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
                       isValid={isValid}
                       isSelected={isSelected}
                       isHovered={isHovered}
+                      isRecentlyPlaced={isRecentlyPlaced}
                       playerColor={playerColor}
                       playerName={playerName}
                       tabIndex={isEntry ? 0 : -1}

--- a/src/components/Board/SettlementMarker.tsx
+++ b/src/components/Board/SettlementMarker.tsx
@@ -19,31 +19,47 @@ export const SettlementMarker: React.FC<SettlementMarkerProps> = ({
       pointerEvents="none"
       className={isRecentlyPlaced ? 'animate-settlement-drop' : undefined}
     >
-      {/* Roof: isosceles triangle, apex pointing up */}
-      <polygon
-        points="-7,0 7,0 0,-9"
-        fill={playerColor}
-        stroke="#1a1a1a"
-        strokeWidth={1.5}
-      />
-      {/* Wall: rectangle below roof */}
-      <rect
-        x={-5.5}
-        y={0}
-        width={11}
-        height={8}
-        fill={playerColor}
-        stroke="#1a1a1a"
-        strokeWidth={1.5}
-      />
-      {/* Door: dark cutout centered at bottom of wall */}
-      <rect
-        x={-2}
-        y={3}
-        width={4}
-        height={5}
-        fill="#1a1a1a"
-      />
+      {/* Ring radiate: expands outward and fades (only when recently placed) */}
+      {isRecentlyPlaced && (
+        <circle
+          cx={0}
+          cy={0}
+          r={0}
+          fill="none"
+          stroke={playerColor}
+          strokeWidth={2}
+          className="animate-settlement-ring"
+          style={{ pointerEvents: 'none' }}
+        />
+      )}
+      {/* House group with drop-shadow for depth */}
+      <g filter="drop-shadow(0 1px 2px rgba(0,0,0,0.35))">
+        {/* Roof: isosceles triangle, apex pointing up */}
+        <polygon
+          points="-7,0 7,0 0,-9"
+          fill={playerColor}
+          stroke="#1a1a1a"
+          strokeWidth={1.5}
+        />
+        {/* Wall: rectangle below roof */}
+        <rect
+          x={-5.5}
+          y={0}
+          width={11}
+          height={8}
+          fill={playerColor}
+          stroke="#1a1a1a"
+          strokeWidth={1.5}
+        />
+        {/* Door: dark cutout centered at bottom of wall */}
+        <rect
+          x={-2}
+          y={3}
+          width={4}
+          height={5}
+          fill="#1a1a1a"
+        />
+      </g>
     </g>
   );
 };

--- a/src/components/Game/TurnBanner.tsx
+++ b/src/components/Game/TurnBanner.tsx
@@ -51,7 +51,7 @@ export const TurnBanner: React.FC<TurnBannerProps> = ({
 
   return (
     <div
-      className="sticky top-0 z-20 flex items-center justify-between gap-3 px-4 py-2 shadow-md"
+      className="animate-banner-enter sticky top-0 z-20 flex items-center justify-between gap-3 px-4 py-2 shadow-md"
       style={{ backgroundColor: currentPlayer.color + 'ee' }}
       role="status"
       aria-label={t('turnBanner.regionLabel', { player: currentPlayer.name, phase: phaseLabel })}

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -169,6 +169,54 @@
 }
 
 /* ----------------------------------------------------------
+ * Settlement ring radiate (ring expands + fades, 250 ms)
+ * Triggered when a settlement is recently placed.
+ * Uses SVG <circle> r attribute animated via CSS.
+ * ---------------------------------------------------------- */
+@keyframes settlementRing {
+  0% {
+    r: 0;
+    opacity: 0.7;
+  }
+  100% {
+    r: 14;
+    opacity: 0;
+  }
+}
+
+.animate-settlement-ring {
+  animation: settlementRing 250ms ease-out forwards;
+}
+
+/* ----------------------------------------------------------
+ * Score pop-in on score increase (scale bounce, 400 ms)
+ * Triggered by key change forcing remount of score span.
+ * ---------------------------------------------------------- */
+@keyframes scorePopIn {
+  0%   { transform: scale(1); }
+  40%  { transform: scale(1.28); color: var(--color-amber-600, #d97706); }
+  100% { transform: scale(1); }
+}
+
+.animate-score-pop {
+  animation: scorePopIn 400ms ease-out both;
+  display: inline-block; /* scale requires non-inline context */
+}
+
+/* ----------------------------------------------------------
+ * TurnBanner enter on player change (slide from top, 200 ms)
+ * Triggered by key={currentPlayer.id} forcing remount.
+ * ---------------------------------------------------------- */
+@keyframes bannerEnter {
+  0%   { transform: translateY(-8px); opacity: 0; }
+  100% { transform: translateY(0);    opacity: 1; }
+}
+
+.animate-banner-enter {
+  animation: bannerEnter 200ms ease-out both;
+}
+
+/* ----------------------------------------------------------
  * Accessibility: disable all animations when user prefers
  * reduced motion (WCAG 2.1 Success Criterion 2.3.3)
  * ---------------------------------------------------------- */

--- a/src/test/HexGrid.recentlyPlaced.test.tsx
+++ b/src/test/HexGrid.recentlyPlaced.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * Tests for HexGrid UI-layer isRecentlyPlaced tracking (issue #141).
+ *
+ * Verifies that when a new settlement appears on the board, the corresponding
+ * HexCell receives isRecentlyPlaced=true (triggering ring + drop animations),
+ * and that it resets to false after ~350 ms.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import React from 'react';
+
+import { HexGrid } from '../components/Board/HexGrid';
+import { Board } from '../core/board';
+import { Terrain } from '../core/terrain';
+import { BotDifficulty, GamePhase } from '../types';
+import type { Player } from '../types';
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function makeBoard(withSettlement?: { q: number; r: number; playerId: number }): Board {
+  const board = new Board(3, 3);
+  board.setCell({ coord: { q: 0, r: 0 }, terrain: Terrain.Grass });
+  board.setCell({ coord: { q: 1, r: 0 }, terrain: Terrain.Grass });
+  board.setCell({ coord: { q: 0, r: 1 }, terrain: Terrain.Grass });
+  if (withSettlement) {
+    board.placeSettlement(
+      { q: withSettlement.q, r: withSettlement.r },
+      withSettlement.playerId,
+    );
+  }
+  return board;
+}
+
+function makePlayer(id: number): Player {
+  return {
+    id,
+    name: `Player${id}`,
+    color: '#ff0000',
+    settlements: [],
+    remainingSettlements: 40,
+    tiles: [],
+    isBot: false,
+    difficulty: BotDifficulty.Normal,
+  };
+}
+
+function makeHexGridProps(board: Board, players: Player[]) {
+  return {
+    board,
+    validPlacements: [],
+    selectedCell: null,
+    players,
+    onCellClick: vi.fn(),
+    onCellSelect: vi.fn(),
+  };
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe('HexGrid isRecentlyPlaced tracking', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('no cell is recently placed on initial render (no settlements)', () => {
+    const board = makeBoard();
+    const players = [makePlayer(1)];
+    const { container } = render(
+      <HexGrid {...makeHexGridProps(board, players)} />,
+    );
+    // animate-settlement-ring element must NOT exist
+    expect(
+      container.querySelector('.animate-settlement-ring'),
+    ).toBeNull();
+  });
+
+  it('ring element appears when a new settlement is placed (prop re-render)', () => {
+    const players = [makePlayer(1)];
+    const boardBefore = makeBoard();
+
+    const { rerender, container } = render(
+      <HexGrid {...makeHexGridProps(boardBefore, players)} />,
+    );
+
+    // Simulate placing a settlement: give HexGrid a new board prop that has a settlement
+    const boardAfter = makeBoard({ q: 0, r: 0, playerId: 1 });
+
+    act(() => {
+      rerender(<HexGrid {...makeHexGridProps(boardAfter, players)} />);
+    });
+
+    // ring element should now be in DOM
+    expect(
+      container.querySelector('.animate-settlement-ring'),
+    ).not.toBeNull();
+  });
+
+  it('recentlyPlacedKey resets to null after 350 ms (setTimeout scheduled)', () => {
+    // Verify that our useEffect schedules a clearTimeout timer.
+    // We use a spy on setTimeout to confirm the 350 ms delay is registered
+    // when a settlement is newly placed.
+    const players = [makePlayer(1)];
+    const boardBefore = makeBoard();
+
+    // Spy on real setTimeout (vi.useFakeTimers in beforeEach replaces it)
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    const { rerender } = render(
+      <HexGrid {...makeHexGridProps(boardBefore, players)} />,
+    );
+
+    const boardAfter = makeBoard({ q: 0, r: 0, playerId: 1 });
+
+    act(() => {
+      rerender(<HexGrid {...makeHexGridProps(boardAfter, players)} />);
+    });
+
+    // A setTimeout of 350 ms should have been scheduled by our useEffect
+    const calls = setTimeoutSpy.mock.calls;
+    const hasResetTimer = calls.some(([, delay]) => delay === 350);
+    expect(hasResetTimer).toBe(true);
+
+    setTimeoutSpy.mockRestore();
+  });
+
+  it('animate-settlement-drop class appears on the settlement group for recently placed cell', () => {
+    const players = [makePlayer(1)];
+    const boardBefore = makeBoard();
+
+    const { rerender, container } = render(
+      <HexGrid {...makeHexGridProps(boardBefore, players)} />,
+    );
+
+    const boardAfter = makeBoard({ q: 0, r: 0, playerId: 1 });
+
+    act(() => {
+      rerender(<HexGrid {...makeHexGridProps(boardAfter, players)} />);
+    });
+
+    expect(
+      container.querySelector('.animate-settlement-drop'),
+    ).not.toBeNull();
+  });
+
+  it('only the newly placed cell gets the ring, not pre-existing settlements', () => {
+    const players = [makePlayer(1)];
+    // Board already has a settlement at (0,0)
+    const boardWithOne = makeBoard({ q: 0, r: 0, playerId: 1 });
+
+    const { rerender, container } = render(
+      <HexGrid {...makeHexGridProps(boardWithOne, players)} />,
+    );
+
+    // Add a second settlement at (1,0)
+    const boardWithTwo = makeBoard({ q: 0, r: 0, playerId: 1 });
+    boardWithTwo.placeSettlement({ q: 1, r: 0 }, 1);
+
+    act(() => {
+      rerender(<HexGrid {...makeHexGridProps(boardWithTwo, players)} />);
+    });
+
+    // Exactly one ring should be present
+    const rings = container.querySelectorAll('.animate-settlement-ring');
+    expect(rings).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #138

## 四項改動摘要

### A. 落子 ring 光暈（SettlementMarker.tsx + animations.css）
- `isRecentlyPlaced=true` 時在 `<g>` 內加一個 SVG `<circle>` ring，套 `.animate-settlement-ring`（`settlementRing` keyframe，r 0→14 + opacity 0.7→0，250ms ease-out forwards）
- ring stroke 顏色 = `playerColor`，`pointerEvents: none`（不擋點擊）
- 房子 `<g>` 加 `filter="drop-shadow(0 1px 2px rgba(0,0,0,0.35))"` 增立體感

### B. 陰影層次（App.tsx）
- HexGrid 外層 div 加 `boxShadow: 'var(--shadow-medium)'`（棋盤浮在底板上）
- 側邊欄地形卡/手牌/目標卡/計分面板原已有 `--shadow-soft`，確認無缺漏

### C. 得分跳動（App.tsx + animations.css）
- 新增 `usePrevious<T>` hook（useRef + useEffect，~10 行，不裝任何 npm）
- 將 live score row 提取為 `ScoreRow` 子元件（hooks 在 map 內無法使用，子元件可安全呼叫 usePrevious）
- `total > prevTotal` 時 span 切 `key={playerId-total}` 強制 remount，套 `.animate-score-pop`（`scorePopIn` keyframe，scale 1→1.28→1，400ms ease-out both + inline-block）

### D. TurnBanner 換玩家過場（TurnBanner.tsx + animations.css）
- `TurnBanner` root `<div>` 加 `animate-banner-enter`（`bannerEnter` keyframe，translateY(-8px)+opacity 0 → 原位+opacity 1，200ms ease-out both）
- `App.tsx` 呼叫處加 `key={currentPlayer?.id}`，確保只有換玩家才 remount；phase 變化（同玩家抽卡/放置）不重觸發

## prefers-reduced-motion

`animations.css` 底部全域 `* { animation-duration: 0.01ms !important }` 覆蓋所有 class（含三個新 class），無需額外處理。

## DoD

- `npx tsc --noEmit` → 0 errors
- `npx vitest run` → 401 tests passed
- `npx vite build` → success (473 kB JS)
- 新 keyframe 全在 prefers-reduced-motion reduce 全域規則下被停用（grep 確認 `@media` block 在 line 223，`*` universal selector 覆蓋）
- src/core/、gameStore、scoring、pan/zoom 邏輯均未異動
- 未安裝任何 npm 套件

🤖 Generated with [Claude Code](https://claude.com/claude-code)