### PR TITLE
feat(sound): R+15 補接 TILE_GAIN/INVALID/TURN_END 音效事件 (#143)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -261,6 +261,35 @@ function App() {
     }
   }, [phase]);
 
+  // TILE_GAIN: play sound when a new history entry contains an acquired tile
+  const prevHistoryLenRef = useRef(history.length);
+
+  useEffect(() => {
+    const prev = prevHistoryLenRef.current;
+    prevHistoryLenRef.current = history.length;
+    if (history.length <= prev) return;           // 防 undo / reset
+    const latest = history[history.length - 1];
+    if (latest?.acquiredTile != null) {
+      console.log('[sound] TILE_GAIN acquired:', latest.acquiredTile);
+      playSound(SoundType.TILE_GAIN);
+    }
+  }, [history]);
+
+  // TURN_END: play sound when turnNumber increases (but not on GameOver)
+  const prevTurnNumberRef = useRef(turnNumber);
+
+  useEffect(() => {
+    if (turnNumber <= prevTurnNumberRef.current) {
+      prevTurnNumberRef.current = turnNumber;
+      return;
+    }
+    prevTurnNumberRef.current = turnNumber;
+    if (phase !== GamePhase.GameOver) {
+      console.log('[sound] TURN_END turn:', turnNumber);
+      playSound(SoundType.TURN_END);
+    }
+  }, [turnNumber, phase]);
+
   useEffect(() => {
     if (phase !== GamePhase.GameOver || finalScores.length === 0 || players.length === 0) {
       submittedGameKeyRef.current = null;
@@ -357,6 +386,19 @@ function App() {
       playSound(SoundType.PLACE);
     }
   }
+
+  // INVALID: play sound when clicking a non-valid cell during PlaceSettlements
+  const invalidClickTimestampRef = useRef(0);
+
+  const handleInvalidCellClick = (_coord: { q: number; r: number }) => {
+    if (!canControlActions) return;
+    if (phase !== GamePhase.PlaceSettlements) return;   // 只在放聚落相響
+    const now = Date.now();
+    if (now - invalidClickTimestampRef.current < 100) return;
+    invalidClickTimestampRef.current = now;
+    console.log('[sound] INVALID click');
+    playSound(SoundType.INVALID);
+  };
 
   const liveScores = players.map(p => ({
     playerId: p.id,
@@ -678,6 +720,7 @@ function App() {
                 onCellClick={handleCellClick}
                 onCellSelect={selectCell}
                 onEscape={handleEscape}
+                onInvalidClick={handleInvalidCellClick}
               />
               </div>
             )}

--- a/src/components/Board/HexGrid.tsx
+++ b/src/components/Board/HexGrid.tsx
@@ -79,6 +79,7 @@ interface HexGridProps {
   onEditCellClick?: (coord: AxialCoord) => void;
   onEditCellPaint?: (coord: AxialCoord) => void;
   editMode?: 'paint' | 'pan';
+  onInvalidClick?: (coord: AxialCoord) => void;
 }
 
 export const HexGrid: React.FC<HexGridProps> = React.memo(({
@@ -93,6 +94,7 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
   onEditCellClick,
   onEditCellPaint,
   editMode = 'paint',
+  onInvalidClick,
 }) => {
   const { t } = useTranslation();
   const [hoveredCell, setHoveredCell] = useState<AxialCoord | null>(null);
@@ -442,6 +444,8 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
                         if (editable) { onEditCellClick?.(cell.coord); return; }
                         if (isValid) {
                           onCellClick(cell.coord);
+                        } else {
+                          onInvalidClick?.(cell.coord);
                         }
                       }}
                       onTap={() => {
@@ -449,6 +453,7 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
                         if (!touchMoved.current) {
                           if (editable) { onEditCellClick?.(cell.coord); return; }
                           if (isValid) onCellClick(cell.coord);
+                          else onInvalidClick?.(cell.coord);
                         }
                       }}
                       onMouseEnter={() => {


### PR DESCRIPTION
## Summary

- **TILE_GAIN**：App.tsx 加 `prevHistoryLenRef` + useEffect，偵測 history 新增且 `latest.acquiredTile != null` 時觸發音效
- **TURN_END**：App.tsx 加 `prevTurnNumberRef` + useEffect，偵測 `turnNumber` 增加且非 GameOver 時觸發音效
- **INVALID**：HexGrid.tsx 加 `onInvalidClick` optional prop（onClick/onTap else 分支），App.tsx 加 `handleInvalidCellClick`（canControlActions + PlaceSettlements 守門 + 100ms debounce）

計劃文件：`/tmp/kingdom-builder-r15-plan-2026-06-03.md`（CPO gray 撰寫，CEO 核准）

## Commits

- `1ed2908` feat(sound): App.tsx 接線 TILE_GAIN / TURN_END 音效 useEffect (#143)
- `d7c078b` feat(sound): HexGrid 加 onInvalidClick prop，onClick/onTap else 分支呼叫 (#143)

## 改動範圍

| 檔案 | 改動 |
|------|------|
| `src/App.tsx` | +43 行：2 個 useEffect（TILE_GAIN/TURN_END）+ 1 個 handler（INVALID）+ 2 個 ref + 1 個 JSX prop |
| `src/components/Board/HexGrid.tsx` | +5 行：onInvalidClick prop 定義 + 解構 + onClick/onTap else 分支 |

**不動**：src/core/、gameStore.ts actions、multiplayerStore.ts、任何測試檔、任何套件

## 自驗結果

- `npx tsc --noEmit`：0 error
- `npx vitest run`：35 test files，406 tests，全部通過
- `npx vite build`（直接跑，跳過 pre-existing tsc -b errors）：✓ built in 869ms，dist 正常產出
- `npx vite preview`：http://localhost:4175/ 開啟正常

> 注意：`npm run build`（tsc -b && vite build）有 4 個 pre-existing errors（App.tsx:1008 TS2322、seasonStore.ts:212 TS2352、HexGrid.recentlyPlaced.test.tsx 兩個 TS6133），均存在於 main 分支，本次改動不引入任何新 error。

## Console 驗證 Log（CTO 自驗確認已出現）

```
[sound] TILE_GAIN acquired: <Location名>
[sound] INVALID click
[sound] TURN_END turn: N
```

## CEO 親測步驟

1. `git pull origin feature/r15-sound-wiring`
2. `npx vite build && npx vite preview`（或 `npm run dev`）
3. 開 Chrome DevTools Console，清空
4. 新局（2 人），依計劃 §7 的 CEO 親測 Checklist 驗收三個音效

## Reviewer

@cancleeric（CEO）請親測後再 merge

---

純 UI 接線，無安全觸發，不需雙審。