### PR TITLE
feat(ui): R+17 Mobile RWD 品質修復（觸控目標 44px + 重複 CTA + drawer + padding）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -728,7 +728,7 @@ function App() {
 
           {/* Mobile floating action bar (< md) — safe-area aware */}
           <div
-            className="lg:hidden flex items-center gap-2 px-4 py-3 flex-shrink-0"
+            className="lg:hidden flex items-center gap-2 px-4 pt-3 pb-14 flex-shrink-0"
             style={{
               backgroundColor: 'var(--color-surface)',
               borderTop: '1px solid var(--card-border)',

--- a/src/components/Game/GameSetup.tsx
+++ b/src/components/Game/GameSetup.tsx
@@ -133,7 +133,7 @@ export function GameSetup({ onStart, onBack }: GameSetupProps) {
       style={{ background: 'var(--texture-parchment)', backgroundColor: 'var(--color-warm-cream-100)' }}
     >
       <div
-        className="rounded-20 w-full max-w-lg p-8"
+        className="rounded-20 w-full max-w-lg p-6 sm:p-8"
         style={{
           backgroundColor: 'var(--card-bg)',
           boxShadow: 'var(--shadow-lifted)',

--- a/src/components/Game/TurnBanner.tsx
+++ b/src/components/Game/TurnBanner.tsx
@@ -111,32 +111,36 @@ export const TurnBanner: React.FC<TurnBannerProps> = ({
       {/* Primary action button */}
       <div className="flex-shrink-0">
         {phase === GamePhase.DrawCard && (
-          <button
-            onClick={onDrawCard}
-            disabled={!canControlActions}
-            aria-label={t('app.drawTerrainCardAria')}
-            data-tutorial-target="draw-card-button"
-            className="flex items-center gap-1.5 text-sm font-bold px-3 py-1.5 rounded-lg transition
-              bg-white text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed
-              focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-          >
-            <DrawCardIcon size={16} />
-            {t('app.drawTerrainCard')}
-          </button>
+          <div className="hidden lg:block flex-shrink-0">
+            <button
+              onClick={onDrawCard}
+              disabled={!canControlActions}
+              aria-label={t('app.drawTerrainCardAria')}
+              data-tutorial-target="draw-card-button"
+              className="flex items-center gap-1.5 text-sm font-bold px-3 py-1.5 rounded-lg transition
+                bg-white text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed
+                focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            >
+              <DrawCardIcon size={16} />
+              {t('app.drawTerrainCard')}
+            </button>
+          </div>
         )}
 
         {shouldShowEndTurnButton && (
-          <button
-            onClick={onEndTurn}
-            disabled={!canControlActions}
-            aria-label={t('app.endTurnAria')}
-            className="flex items-center gap-1.5 text-sm font-bold px-3 py-1.5 rounded-lg transition
-              bg-white text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed
-              focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-          >
-            <EndTurnIcon size={16} />
-            {t('app.endTurn')}
-          </button>
+          <div className="hidden lg:block flex-shrink-0">
+            <button
+              onClick={onEndTurn}
+              disabled={!canControlActions}
+              aria-label={t('app.endTurnAria')}
+              className="flex items-center gap-1.5 text-sm font-bold px-3 py-1.5 rounded-lg transition
+                bg-white text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed
+                focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            >
+              <EndTurnIcon size={16} />
+              {t('app.endTurn')}
+            </button>
+          </div>
         )}
 
         {phase === GamePhase.PlaceSettlements && validPlacements.length > 0 && (

--- a/src/components/Mobile/BottomDrawer.tsx
+++ b/src/components/Mobile/BottomDrawer.tsx
@@ -133,8 +133,8 @@ export const BottomDrawer: React.FC<BottomDrawerProps> = ({
           onKeyDown={e => e.key === 'Enter' && onToggle()}
         >
           <div
-            className="w-10 h-1 rounded-full mb-1"
-            style={{ backgroundColor: 'var(--color-stone-300)' }}
+            className="w-12 h-1.5 rounded-full mb-1"
+            style={{ backgroundColor: 'var(--color-stone-400)' }}
           />
           <div
             className="flex items-center justify-between w-full px-4 py-1"

--- a/src/components/UI/ModalFrame.tsx
+++ b/src/components/UI/ModalFrame.tsx
@@ -226,7 +226,7 @@ export const ModalFrame = React.memo(function ModalFrame({
         <button
           onClick={onClose}
           aria-label="Close"
-          className="shrink-0 flex items-center justify-center w-8 h-8 rounded-full transition"
+          className="shrink-0 flex items-center justify-center w-11 h-11 rounded-full transition"
           style={{ color: 'var(--color-stone-500)' }}
         >
           <CloseIcon size={18} />


### PR DESCRIPTION
## 計劃來源

CPO Gray 計劃文件：`/tmp/kingdom-builder-r17-plan-2026-06-03.md`（4 gap 行號已驗證屬實）

## 修復內容

| Gap | 檔案 | 變更 |
|-----|------|------|
| Gap-1 | `src/components/Game/TurnBanner.tsx` | DrawCard / EndTurn 按鈕加 `hidden lg:block` wrapper，mobile 由 floating bar 唯一提供 CTA，消除雙重操作入口 |
| Gap-2 | `src/components/UI/ModalFrame.tsx:229` | Close 按鈕 `w-8 h-8`（32px）→ `w-11 h-11`（44px），符合 WCAG/Apple HIG 觸控目標 |
| Gap-3 | `src/components/Mobile/BottomDrawer.tsx:136` + `src/App.tsx:731` | 把手灰條 `w-10 h-1 stone-300` → `w-12 h-1.5 stone-400`；floating bar `py-3` → `pt-3 pb-14` 防 fixed handle 遮蓋 |
| Gap-4 | `src/components/Game/GameSetup.tsx:136` | `p-8` → `p-6 sm:p-8`，390px 下防截字 |

## Commit 清單

- `f408dbd` fix(ui): Gap-1 TurnBanner mobile 隱藏重複 CTA（DrawCard/EndTurn 按鈕）
- `fba3fb7` fix(ui): Gap-2 ModalFrame Close 按鈕觸控目標 32px→44px
- `5149c4f` fix(ui): Gap-3 BottomDrawer handle 對比加強 + floating bar pb-14 防遮蓋
- `5c0343b` fix(ui): Gap-4 GameSetup p-8 → p-6 sm:p-8，390px 下防截字

## Mobile 截圖（390×844 Playwright isolated context）

| # | 截圖 | 驗收要點 |
|---|------|---------|
| 01 | `/tmp/r17-screenshots/01-main-menu.png` | 主選單正常顯示 |
| 02 | `/tmp/r17-screenshots/02-game-drawcard.png` | TurnBanner 無 DrawCard 按鈕（mobile 隱藏），floating bar 唯一 Draw 入口 ✅ |
| 03 | `/tmp/r17-screenshots/03-game-placesettle.png` | floating bar 底部未被 drawer handle 遮蓋（pb-14 有效）✅ |
| 04 | `/tmp/r17-screenshots/04-drawer-open.png` | Drawer 開啟，把手灰條清晰可見（w-12 h-1.5 stone-400）✅ |
| 05 | `/tmp/r17-screenshots/05-gameover.png` | GameOver overlay 完整顯示（bot vs bot 實跑至結束）✅ |
| 06 | `/tmp/r17-screenshots/06-leaderboard-modal.png` | LeaderboardModal Close 按鈕測量 44×44px ✅ |
| 07 | `/tmp/r17-screenshots/07-gamesetup.png` | GameSetup p-6 padding，按鈕/輸入不截字 ✅ |

## 自驗結果

- `npx tsc --noEmit`：0 error
- `npx vitest run`：406 tests passed (35 files)
- `npx vite build`：成功（786ms）

## 安全性

純 CSS/Tailwind class 修改，不動 `src/core/`、gameStore actions、scoring、multiplayer，不引新套件，無 DB/外部服務觸及，不需安全雙審。

---

Reviewer: @cancleeric （CEO Nicholas 親驗）

🤖 Generated with [Claude Code](https://claude.com/claude-code)