### PR TITLE
fix(ui): R+18 成就 Toast 入場動畫修復(animate-bounce-in 未定義) + 解鎖音效

### DIFF
--- a/src/components/Game/AchievementToast.tsx
+++ b/src/components/Game/AchievementToast.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAchievementStore } from '../../store/achievementStore';
+import { initAudio, playSound, SoundType } from '../../utils/soundEngine';
 
 const TOAST_DURATION_MS = 4000;
 
@@ -13,6 +14,8 @@ export function AchievementToast() {
 
   useEffect(() => {
     if (!currentId) return;
+    initAudio();
+    playSound(SoundType.ACHIEVEMENT);
     const timer = setTimeout(dismissToast, TOAST_DURATION_MS);
     return () => clearTimeout(timer);
   }, [currentId, dismissToast]);
@@ -23,7 +26,7 @@ export function AchievementToast() {
     <div
       role="status"
       aria-live="polite"
-      className="fixed bottom-24 left-1/2 -translate-x-1/2 z-50 animate-bounce-in"
+      className="fixed bottom-24 left-1/2 -translate-x-1/2 z-50 animate-achievement-bounce-in"
     >
       <div className="bg-yellow-400 text-yellow-900 rounded-2xl shadow-xl px-6 py-4 flex items-center gap-3 max-w-xs">
         <span className="text-3xl" aria-hidden="true">🏅</span>

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -204,6 +204,23 @@
 }
 
 /* ----------------------------------------------------------
+ * Achievement Toast bounce-in (scale 0.4→1.08→1, 320 ms)
+ * Triggered when a new achievement is unlocked.
+ * translateX(-50%) must be preserved in every step to keep
+ * the toast horizontally centred (mirrors Tailwind -translate-x-1/2).
+ * ---------------------------------------------------------- */
+@keyframes achievementBounceIn {
+  0%   { transform: translateX(-50%) scale(0.4);  opacity: 0; }
+  60%  { transform: translateX(-50%) scale(1.08); opacity: 1; }
+  80%  { transform: translateX(-50%) scale(0.97); }
+  100% { transform: translateX(-50%) scale(1);    opacity: 1; }
+}
+
+.animate-achievement-bounce-in {
+  animation: achievementBounceIn 320ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+/* ----------------------------------------------------------
  * TurnBanner enter on player change (slide from top, 200 ms)
  * Triggered by key={currentPlayer.id} forcing remount.
  * ---------------------------------------------------------- */

--- a/src/utils/soundEngine.test.ts
+++ b/src/utils/soundEngine.test.ts
@@ -160,5 +160,45 @@ describe('soundEngine', () => {
 
       expect(mockGain.gain.setValueAtTime).toHaveBeenCalledWith(0.15, 0);
     });
+
+    it('ACHIEVEMENT: schedules 4 oscillators for rising arpeggio', async () => {
+      const { MockAudioContext, instance } = makeMockAudioContext();
+      vi.stubGlobal('AudioContext', MockAudioContext);
+      const { initAudio, playSound, setMuted, SoundType } = await import('./soundEngine');
+      initAudio();
+
+      setMuted(false);
+      playSound(SoundType.ACHIEVEMENT);
+
+      // 4 notes → createOscillator called 4 times
+      expect(instance.createOscillator).toHaveBeenCalledTimes(4);
+    });
+
+    it('ACHIEVEMENT: does not schedule oscillators when muted', async () => {
+      const { MockAudioContext, instance } = makeMockAudioContext();
+      vi.stubGlobal('AudioContext', MockAudioContext);
+      const { initAudio, playSound, setMuted, SoundType } = await import('./soundEngine');
+      initAudio();
+
+      setMuted(true);
+      playSound(SoundType.ACHIEVEMENT);
+
+      expect(instance.createOscillator).not.toHaveBeenCalled();
+    });
+
+    it('ACHIEVEMENT: uses gain value 0.25 at full volume', async () => {
+      const { MockAudioContext, mockGain } = makeMockAudioContext();
+      vi.stubGlobal('AudioContext', MockAudioContext);
+      const { initAudio, playSound, setMuted, setVolume, SoundType } = await import('./soundEngine');
+      initAudio();
+
+      setMuted(false);
+      setVolume(1);
+      playSound(SoundType.ACHIEVEMENT);
+
+      // Each of the 4 notes calls gain.setValueAtTime(0.25 * volume, startTime)
+      // First note starts at currentTime=0, gain = 0.25 * 1 = 0.25
+      expect(mockGain.gain.setValueAtTime).toHaveBeenCalledWith(0.25, 0);
+    });
   });
 });

--- a/src/utils/soundEngine.ts
+++ b/src/utils/soundEngine.ts
@@ -4,6 +4,7 @@ export enum SoundType {
   INVALID = 'INVALID',
   TURN_END = 'TURN_END',
   GAME_OVER = 'GAME_OVER',
+  ACHIEVEMENT = 'ACHIEVEMENT',
 }
 
 const MUTE_STORAGE_KEY = 'kingdom-builder-muted';
@@ -129,6 +130,17 @@ export function playSound(type: SoundType): void {
         const noteDuration = 0.06;
         gameOverFreqs.forEach((freq, i) => {
           playTone(ctx, freq, noteDuration, 'sine', now + i * noteDuration);
+        });
+        break;
+      }
+
+      case SoundType.ACHIEVEMENT: {
+        // 4-note rising arpeggio: C5→E5→G5→C6, interval 90ms, gain 0.25
+        // 4th note duration 150ms (extended), others 70ms
+        const freqs = [523, 659, 784, 1047];
+        const durations = [0.07, 0.07, 0.07, 0.15];
+        freqs.forEach((freq, i) => {
+          playTone(ctx, freq, durations[i], 'sine', now + i * 0.09, 0.25);
         });
         break;
       }


### PR DESCRIPTION
## 計劃來源

/tmp/kingdom-builder-r18-plan-2026-06-03.md（CPO gray 撰寫，CEO 核准）

## 問題摘要

- `AchievementToast.tsx` 使用 `animate-bounce-in`，但該 class 從未在 animations.css / tailwind.config 定義，Tailwind v4 build 時 silent drop，Toast 以無動畫方式瞬閃出現。
- 成就解鎖時完全靜音，與 TILE_GAIN 等其他事件有音效形成反差。

## Commit 清單

| SHA | 說明 |
|-----|------|
| a9eee2f | fix(ui): R+18(a) 補 achievementBounceIn keyframe + .animate-achievement-bounce-in |
| b44309a | feat(sound): R+18(b) soundEngine 加入 ACHIEVEMENT 音效 + 補單元測試 |
| 8659187 | fix(ui): R+18(c) AchievementToast 換用 animate-achievement-bounce-in + 解鎖音效 |

## 改動範圍（僅 4 檔）

- `src/styles/animations.css` — 新增 `@keyframes achievementBounceIn` + `.animate-achievement-bounce-in`（translateX(-50%) 保留，防止 scale 飛偏）
- `src/utils/soundEngine.ts` — SoundType enum 加 ACHIEVEMENT；playSound 加 C5→E5→G5→C6 四音符 arpeggio case
- `src/components/Game/AchievementToast.tsx` — class 名替換 + import soundEngine + useEffect 加 initAudio/playSound
- `src/utils/soundEngine.test.ts` — 補 3 個 ACHIEVEMENT 單測（oscillator 數量、靜音守衛、gain 值）

未動：src/core/、gameStore actions、achievementStore toastQueue、scoring、multiplayer。未引入新套件。

## 自驗結果

- `npx tsc --noEmit` — 0 error
- `npx vitest run src/utils/soundEngine.test.ts` — 15/15 pass
- `npx vitest run` — 35 files，409 tests，全綠
- `npx vite build` — built in 717ms，0 error（warning 為既有 dynamic import，非本次引入）
- grep `animate-bounce-in` AchievementToast.tsx — NOT FOUND（舊 class 已移除）
- grep `achievementBounceIn` animations.css — 第 212、220 行確認存在

## Reviewer

@cancleeric（CEO Nicholas 親驗）

⛔ 請勿自行 merge，等 CEO 親驗後決定。