### PR TITLE
style(ui): R+19 設計系統一致性 sweep（5 元件通用色→token）

### DIFF
--- a/src/components/Board/HexGrid.tsx
+++ b/src/components/Board/HexGrid.tsx
@@ -350,7 +350,7 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
 
   return (
     <div
-      className="w-full h-full flex items-center justify-center bg-gray-100 overflow-hidden relative select-none"
+      className="w-full h-full flex items-center justify-center overflow-hidden relative select-none"
       ref={containerRef}
       role="grid"
       aria-label={t('board.gridLabel')}
@@ -369,11 +369,14 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
         lastPaintedCoord.current = null;
         onTouchEnd(e);
       }}
-      style={{ cursor: editable && editMode === 'paint' ? 'crosshair' : 'grab', touchAction: 'none' }}
+      style={{ cursor: editable && editMode === 'paint' ? 'crosshair' : 'grab', touchAction: 'none', background: 'var(--color-warm-cream-200)' }}
     >
       {/* Zoom reset button */}
       <button
-        className="absolute top-2 right-2 z-10 bg-white/80 hover:bg-white border border-gray-300 rounded-full w-9 h-9 text-sm font-bold shadow flex items-center justify-center"
+        className="absolute top-2 right-2 z-10 rounded-full w-9 h-9 text-sm font-bold shadow flex items-center justify-center"
+        style={{ background: 'oklch(0.98 0.01 85 / 0.85)', border: '1px solid var(--card-border)' }}
+        onMouseEnter={e => (e.currentTarget.style.background = 'var(--color-surface)')}
+        onMouseLeave={e => (e.currentTarget.style.background = 'oklch(0.98 0.01 85 / 0.85)')}
         onClick={reset}
         title={t('board.resetZoomTitle')}
         aria-label={t('board.resetZoomAria')}
@@ -382,7 +385,10 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
       </button>
 
       {/* Zoom level badge */}
-      <div className="absolute bottom-2 right-2 z-10 bg-white/70 text-xs text-gray-600 rounded px-2 py-0.5 pointer-events-none">
+      <div
+        className="absolute bottom-2 right-2 z-10 text-xs rounded px-2 py-0.5 pointer-events-none"
+        style={{ background: 'oklch(0.98 0.01 85 / 0.75)', color: 'var(--color-stone-500)' }}
+      >
         {Math.round(transform.scale * 100)}%
       </div>
 

--- a/src/components/Game/AchievementToast.tsx
+++ b/src/components/Game/AchievementToast.tsx
@@ -28,7 +28,10 @@ export function AchievementToast() {
       aria-live="polite"
       className="fixed bottom-24 left-1/2 -translate-x-1/2 z-50 animate-achievement-bounce-in"
     >
-      <div className="bg-yellow-400 text-yellow-900 rounded-2xl shadow-xl px-6 py-4 flex items-center gap-3 max-w-xs">
+      <div
+        className="rounded-2xl shadow-xl px-6 py-4 flex items-center gap-3 max-w-xs"
+        style={{ background: 'var(--color-amber-400)', color: 'var(--color-amber-900)' }}
+      >
         <span className="text-3xl" aria-hidden="true">🏅</span>
         <div>
           <p className="text-xs font-semibold uppercase tracking-wide">

--- a/src/components/Game/GameLog.tsx
+++ b/src/components/Game/GameLog.tsx
@@ -56,7 +56,7 @@ export const GameLog = React.memo(function GameLog({ history, players }: GameLog
     return (
       <div className="mb-4">
         <h3 className="text-lg font-semibold mb-2">{t('gameLog.heading')}</h3>
-        <p className="text-xs text-gray-400 italic">{t('gameLog.empty')}</p>
+        <p className="text-xs italic" style={{ color: 'var(--color-stone-400)' }}>{t('gameLog.empty')}</p>
       </div>
     );
   }
@@ -82,7 +82,7 @@ export const GameLog = React.memo(function GameLog({ history, players }: GameLog
               </span>{' '}
               {actionLabel(action, t)}
               {action.acquiredTile && (
-                <span className="ml-1 text-gray-500">
+                <span className="ml-1" style={{ color: 'var(--color-stone-500)' }}>
                   {t('gameLog.acquiredTile', {
                     emoji: LOCATION_EMOJI[action.acquiredTile] ?? '',
                     tile: tLocation(t, action.acquiredTile),

--- a/src/components/Game/TurnBanner.tsx
+++ b/src/components/Game/TurnBanner.tsx
@@ -118,8 +118,11 @@ export const TurnBanner: React.FC<TurnBannerProps> = ({
               aria-label={t('app.drawTerrainCardAria')}
               data-tutorial-target="draw-card-button"
               className="flex items-center gap-1.5 text-sm font-bold px-3 py-1.5 rounded-lg transition
-                bg-white text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed
+                disabled:opacity-50 disabled:cursor-not-allowed
                 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+              style={{ background: 'var(--color-surface)', color: 'var(--color-text)' }}
+              onMouseEnter={e => (e.currentTarget.style.background = 'var(--color-warm-cream-200)')}
+              onMouseLeave={e => (e.currentTarget.style.background = 'var(--color-surface)')}
             >
               <DrawCardIcon size={16} />
               {t('app.drawTerrainCard')}
@@ -134,8 +137,11 @@ export const TurnBanner: React.FC<TurnBannerProps> = ({
               disabled={!canControlActions}
               aria-label={t('app.endTurnAria')}
               className="flex items-center gap-1.5 text-sm font-bold px-3 py-1.5 rounded-lg transition
-                bg-white text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed
+                disabled:opacity-50 disabled:cursor-not-allowed
                 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+              style={{ background: 'var(--color-surface)', color: 'var(--color-text)' }}
+              onMouseEnter={e => (e.currentTarget.style.background = 'var(--color-warm-cream-200)')}
+              onMouseLeave={e => (e.currentTarget.style.background = 'var(--color-surface)')}
             >
               <EndTurnIcon size={16} />
               {t('app.endTurn')}

--- a/src/components/Menu/SettingsModal.tsx
+++ b/src/components/Menu/SettingsModal.tsx
@@ -32,18 +32,26 @@ export const SettingsModal = React.memo(function SettingsModal({
   return (
     <div className="fixed inset-0 z-[60] bg-black/70 flex items-center justify-center px-4">
       <div
-        className="bg-white rounded-xl shadow-2xl p-6 max-w-md w-full"
+        className="rounded-xl shadow-2xl p-6 max-w-md w-full"
+        style={{ background: 'var(--color-surface)' }}
         role="dialog"
         aria-modal="true"
         aria-labelledby="settings-heading"
       >
         <div className="flex items-center justify-between gap-3 mb-5">
-          <h3 id="settings-heading" className="text-2xl font-bold text-gray-900">
+          <h3
+            id="settings-heading"
+            className="text-2xl font-bold"
+            style={{ color: 'var(--color-text)' }}
+          >
             {t('settings.heading')}
           </h3>
           <button
             onClick={onClose}
-            className="w-9 h-9 rounded-full flex items-center justify-center text-gray-600 hover:bg-gray-100 hover:text-gray-900 transition"
+            className="w-9 h-9 rounded-full flex items-center justify-center transition"
+            style={{ color: 'var(--color-stone-500)' }}
+            onMouseEnter={e => (e.currentTarget.style.background = 'var(--button-ghost-bg-hover)')}
+            onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
             aria-label={t('settings.close')}
             title={t('settings.close')}
           >
@@ -53,7 +61,11 @@ export const SettingsModal = React.memo(function SettingsModal({
 
         <div className="space-y-5">
           <section aria-labelledby="settings-audio-heading" className="space-y-3">
-            <h4 id="settings-audio-heading" className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+            <h4
+              id="settings-audio-heading"
+              className="text-sm font-semibold uppercase tracking-wide"
+              style={{ color: 'var(--color-stone-600)' }}
+            >
               {t('settings.audio')}
             </h4>
 
@@ -61,19 +73,28 @@ export const SettingsModal = React.memo(function SettingsModal({
               type="button"
               onClick={onToggleMute}
               aria-pressed={muted}
-              className="w-full flex items-center justify-between gap-3 rounded-lg border border-gray-200 px-4 py-3 text-left hover:bg-gray-50 transition"
+              className="w-full flex items-center justify-between gap-3 rounded-lg px-4 py-3 text-left transition"
+              style={{ border: '1px solid var(--card-border)' }}
+              onMouseEnter={e => (e.currentTarget.style.background = 'var(--color-warm-cream-100)')}
+              onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
             >
-              <span className="flex items-center gap-2 font-semibold text-gray-900">
+              <span
+                className="flex items-center gap-2 font-semibold"
+                style={{ color: 'var(--color-text)' }}
+              >
                 {muted ? <MutedIcon size={18} /> : <UnmutedIcon size={18} />}
                 {t('settings.mute')}
               </span>
-              <span className="text-sm text-gray-600">
+              <span className="text-sm" style={{ color: 'var(--color-stone-500)' }}>
                 {muted ? t('settings.muted') : t('settings.unmuted')}
               </span>
             </button>
 
             <label className="block" htmlFor="settings-volume">
-              <span className="flex items-center justify-between text-sm font-semibold text-gray-700 mb-2">
+              <span
+                className="flex items-center justify-between text-sm font-semibold mb-2"
+                style={{ color: 'var(--color-stone-600)' }}
+              >
                 <span>{t('settings.volume')}</span>
                 <span>{t('settings.volumeValue', { value: volumePercent })}</span>
               </span>
@@ -86,20 +107,25 @@ export const SettingsModal = React.memo(function SettingsModal({
                 step="5"
                 value={volumePercent}
                 onChange={(event) => onVolumeChange(Number(event.target.value) / 100)}
-                className="w-full accent-blue-600"
+                className="w-full accent-[var(--color-wine-600)]"
               />
             </label>
           </section>
 
           <section aria-labelledby="settings-language-heading" className="space-y-2">
-            <h4 id="settings-language-heading" className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+            <h4
+              id="settings-language-heading"
+              className="text-sm font-semibold uppercase tracking-wide"
+              style={{ color: 'var(--color-stone-600)' }}
+            >
               {t('settings.language')}
             </h4>
             <select
               value={language}
               onChange={(event) => onLanguageChange(event.target.value)}
               aria-label={t('common.language')}
-              className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm text-gray-900 bg-white"
+              className="w-full rounded-lg px-3 py-2 text-sm"
+              style={{ border: '1px solid var(--card-border)', background: 'var(--color-surface)', color: 'var(--color-text)' }}
             >
               <option value="en">{t('common.english')}</option>
               <option value="zh-TW">{t('common.traditionalChinese')}</option>


### PR DESCRIPTION
## 計劃

[R19 CPO 計劃](/tmp/kingdom-builder-r19-plan-2026-06-03.md)（本機路徑：`/tmp/kingdom-builder-r19-plan-2026-06-03.md`）

## 改動元件

| 元件 | 處數 | 說明 |
|------|------|------|
| SettingsModal.tsx | 9 | bg-white→surface、text-gray-*→stone token、border-gray→card-border、hover inline、accent→wine-600、select 三色→token |
| AchievementToast.tsx | 2 | bg-yellow-400/text-yellow-900→amber token |
| TurnBanner.tsx | 2 | DrawCard/EndTurn 按鈕 bg-white text-gray-800→surface/text + onMouseEnter/Leave |
| GameLog.tsx | 2 | text-gray-400/500→stone-400/500 |
| HexGrid.tsx | 3 | 棋盤底 bg-gray-100→warm-cream-200；zoom button/badge→oklch inline |

## Commit List

- `134035f` style(ui): R+19(1) SettingsModal 通用色→設計 token（9 處）
- `9cd37c2` style(ui): R+19(2) AchievementToast bg-yellow→amber token
- `9066a0d` style(ui): R+19(3) TurnBanner 兩按鈕通用白→surface token
- `896e2d3` style(ui): R+19(4) GameLog text-gray→stone token（2 處）
- `85225f6` style(ui): R+19(5) HexGrid 容器三處通用色→warm-cream token

## 自驗結果

| 項目 | 結果 |
|------|------|
| `npx tsc --noEmit` | 0 error |
| `npx vitest run` | 409 passed（35 suites，無新失敗）|
| `npx vite build` | 成功（810ms，warning 為 pre-existing dynamic import，非本次引入）|

## 保留色確認

- **TurnBanner**：`text-white`、`bg-white/25`、`bg-white/30`、`text-white/90`、`text-white/80` 全部保留（玩家色背景 overlay 刻意設計）
- **GameLog**：`style={{ borderColor: color }}` 與 `style={{ color }}` 保留（玩家識別色）
- **HexGrid**：SVG 內部 HexCell/TerrainDefs 未動；棋盤底 bg-gray-100 已移除

## 範圍控制

未動：ReplayViewer、ReplayList、SaveLoadUI、InstallPrompt（下輪）。
未動：`src/core/`、gameStore actions、scoring、multiplayer。
未引新套件。未使用 Tailwind v3 三件式。

## Reviewer

@cancleeric（CEO Nicholas 驗收）