### PR TITLE
feat(onboarding): R+20 新玩家首次自動引導（dismiss 修正 + OnboardingPrompt）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { GameSetup } from './components/Game/GameSetup'
 import { MultiplayerSetup } from './components/Game/MultiplayerSetup'
 import { MainMenu } from './components/Menu/MainMenu'
 import { TutorialOverlay } from './components/Tutorial/TutorialOverlay'
+import { OnboardingPromptModal } from './components/Tutorial/OnboardingPromptModal'
 import { useTutorialStore } from './store/tutorialStore'
 import { TurnBanner } from './components/Game/TurnBanner'
 import { ObjectiveCardBadge } from './components/Game/ObjectiveCardBadge'
@@ -126,6 +127,7 @@ function App() {
   const [replayOpen, setReplayOpen] = useState(false);
   const [achievementOpen, setAchievementOpen] = useState(false);
   const [seasonHistoryOpen, setSeasonHistoryOpen] = useState(false);
+  const [showOnboardingPrompt, setShowOnboardingPrompt] = useState(false);
   const broadcastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const submittedGameKeyRef = useRef<string | null>(null);
 
@@ -213,6 +215,11 @@ function App() {
   const handleStart = (configs: PlayerConfig[], options: GameOptions, customBoard?: Board) => {
     initGame(configs, options, customBoard);
     setGameStarted(true);
+    // First-time player onboarding prompt (single player only)
+    const { hasCompleted } = useTutorialStore.getState();
+    if (!hasCompleted && !isNetworkGame) {
+      setShowOnboardingPrompt(true);
+    }
   };
 
   const handleToggleMute = () => {
@@ -1284,6 +1291,19 @@ function App() {
 
       {/* Achievement unlock toast notification */}
       <AchievementToast />
+
+      {/* Onboarding prompt — shown to first-time players after game start */}
+      <OnboardingPromptModal
+        isOpen={showOnboardingPrompt}
+        onStartTutorial={() => {
+          setShowOnboardingPrompt(false);
+          useTutorialStore.getState().startTutorial();
+        }}
+        onSkip={() => {
+          setShowOnboardingPrompt(false);
+          useTutorialStore.getState().completeTutorial();
+        }}
+      />
 
       {/* Tutorial overlay – available from any screen */}
       <TutorialOverlay />

--- a/src/components/Tutorial/OnboardingPromptModal.tsx
+++ b/src/components/Tutorial/OnboardingPromptModal.tsx
@@ -1,0 +1,124 @@
+import { useTranslation } from 'react-i18next';
+
+interface OnboardingPromptModalProps {
+  isOpen: boolean;
+  onStartTutorial: () => void;
+  onSkip: () => void;
+}
+
+/**
+ * OnboardingPromptModal — shown to first-time players after game start.
+ *
+ * Asks whether the player wants a quick tutorial.
+ * - "Show Me How" → starts tutorial
+ * - "Skip for Now" → marks tutorial completed (permanent, no re-prompt)
+ *
+ * z-index: z-[80] — above TutorialOverlay (z-[70]) and ModalFrame coachmark (z-[70])
+ * Tailwind v4: all colours via CSS design tokens (no v3 three-part syntax)
+ */
+export function OnboardingPromptModal({
+  isOpen,
+  onStartTutorial,
+  onSkip,
+}: OnboardingPromptModalProps) {
+  const { t } = useTranslation();
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        aria-hidden="true"
+        className="fixed inset-0 z-[79]"
+        style={{ backgroundColor: 'oklch(0 0 0 / 0.55)' }}
+      />
+
+      {/* Modal panel */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('tutorial.onboardingPrompt.title')}
+        className="fixed inset-0 z-[80] flex items-center justify-center px-4"
+      >
+        <div
+          className="relative w-full max-w-sm rounded-[var(--radius-14)] overflow-hidden animate-modal-enter"
+          style={{
+            backgroundColor: 'var(--color-surface)',
+            boxShadow: 'var(--shadow-lifted)',
+            border: '1px solid var(--card-border)',
+          }}
+        >
+          {/* 4px wine accent rail */}
+          <div
+            aria-hidden="true"
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              bottom: 0,
+              width: 4,
+              backgroundColor: 'var(--color-wine-600)',
+              borderTopLeftRadius: 'var(--radius-14)',
+              borderBottomLeftRadius: 'var(--radius-14)',
+            }}
+          />
+
+          {/* Content */}
+          <div className="px-6 py-6" style={{ paddingLeft: '1.75rem' }}>
+            {/* Crown icon */}
+            <div className="flex items-center gap-3 mb-3">
+              <span className="text-3xl" aria-hidden="true">👑</span>
+              <h2
+                className="font-bold"
+                style={{
+                  fontFamily: 'var(--font-display)',
+                  fontSize: 'var(--type-display-sm)',
+                  lineHeight: 'var(--line-height-display)',
+                  color: 'var(--color-text)',
+                }}
+              >
+                {t('tutorial.onboardingPrompt.title')}
+              </h2>
+            </div>
+
+            <p
+              className="mb-6 text-sm"
+              style={{
+                color: 'var(--color-stone-600)',
+                lineHeight: 'var(--line-height-body)',
+              }}
+            >
+              {t('tutorial.onboardingPrompt.description')}
+            </p>
+
+            {/* Buttons */}
+            <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+              <button
+                onClick={onSkip}
+                className="px-5 py-2.5 rounded-xl text-sm font-medium transition"
+                style={{
+                  border: '1px solid var(--card-border)',
+                  color: 'var(--color-stone-600)',
+                  backgroundColor: 'transparent',
+                }}
+              >
+                {t('tutorial.onboardingPrompt.skipButton')}
+              </button>
+              <button
+                onClick={onStartTutorial}
+                className="px-5 py-2.5 rounded-xl text-sm font-semibold transition"
+                style={{
+                  backgroundColor: 'var(--button-primary-bg)',
+                  color: 'var(--button-text)',
+                }}
+              >
+                {t('tutorial.onboardingPrompt.startButton')}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -408,6 +408,12 @@ export const en = {
     next: 'Next →',
     keyboardHint: 'Press left/right arrow keys to navigate · Esc to close',
     performHighlightedAction: 'Perform the highlighted action to continue automatically.',
+    onboardingPrompt: {
+      title: 'First time playing?',
+      description: 'Would you like a quick tutorial to learn the rules?',
+      startButton: 'Show Me How',
+      skipButton: 'Skip for Now',
+    },
     steps: {
       welcome: {
         title: 'Welcome to Kingdom Builder!',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -406,6 +406,12 @@ export const zhTW = {
     next: '下一步 →',
     keyboardHint: '按左右方向鍵切換 · Esc 關閉',
     performHighlightedAction: '執行高亮操作即可自動前進。',
+    onboardingPrompt: {
+      title: '第一次玩嗎？',
+      description: '要看快速教學了解遊戲規則嗎？',
+      startButton: '開始教學',
+      skipButton: '先跳過',
+    },
     steps: {
       welcome: {
         title: '歡迎來到王國建造者！',

--- a/src/store/tutorialStore.ts
+++ b/src/store/tutorialStore.ts
@@ -166,6 +166,5 @@ export const useTutorialStore = create<TutorialState>((set) => ({
 
   completeTutorial: () => set(markCompleted),
 
-  dismissTutorial: () =>
-    set({ isActive: false }),
+  dismissTutorial: () => set(markCompleted),
 }));

--- a/src/test/tutorialStore.test.ts
+++ b/src/test/tutorialStore.test.ts
@@ -86,13 +86,27 @@ describe('tutorialStore', () => {
     expect(useTutorialStore.getState().currentStepIndex).toBe(TUTORIAL_STEPS.length - 1);
   });
 
-  it('dismissTutorial deactivates without marking completion', () => {
+  it('dismissTutorial deactivates AND marks completion (Bug 1 fix)', () => {
     useTutorialStore.getState().startTutorial();
     useTutorialStore.getState().dismissTutorial();
     const { isActive, hasCompleted } = useTutorialStore.getState();
     expect(isActive).toBe(false);
-    expect(hasCompleted).toBe(false);
+    expect(hasCompleted).toBe(true);
+    expect(localStorageMock.getItem('tutorialCompleted')).toBe('true');
+  });
+
+  it('dismissTutorial writes tutorialCompleted to localStorage', () => {
+    useTutorialStore.getState().startTutorial();
     expect(localStorageMock.getItem('tutorialCompleted')).toBeNull();
+    useTutorialStore.getState().dismissTutorial();
+    expect(localStorageMock.getItem('tutorialCompleted')).toBe('true');
+  });
+
+  it('dismissTutorial sets isActive to false', () => {
+    useTutorialStore.getState().startTutorial();
+    expect(useTutorialStore.getState().isActive).toBe(true);
+    useTutorialStore.getState().dismissTutorial();
+    expect(useTutorialStore.getState().isActive).toBe(false);
   });
 
   it('completeTutorial deactivates and persists to localStorage', () => {


### PR DESCRIPTION
## 計劃來源

R+20 計劃：新玩家首次自動引導（CPO 撰寫，CEO 核准）

## 改動摘要

### Bug 1 修正：dismissTutorial 現在寫 hasCompleted
- 修正前：X / ESC 只關 overlay，hasCompleted 仍 false，下次開局仍自動觸發（無限循環）
- 修正後：dismiss = 玩家確認跳過，永久記憶，不再打擾

### 新功能：OnboardingPromptModal
- 首次開局（hasCompleted===false + 單人局）後自動彈出
- 「Show Me How / 開始教學」→ startTutorial()
- 「Skip for Now / 先跳過」→ completeTutorial()（寫 localStorage）
- z-[80]，高於 TutorialOverlay z-[70]
- 設計 token：wine-600 accent / surface / card-border / button-primary
- 多人局 isNetworkGame guard 排除

## Commit List

- `ce94246` fix(tutorial): dismissTutorial 修正為 markCompleted（Bug 1）
- `45a49f5` feat(tutorial): 新增 OnboardingPromptModal 元件
- `f8c9ff5` feat(onboarding): App.tsx 加入首次開局自動觸發邏輯
- `c702d35` i18n: 新增 tutorial.onboardingPrompt 四鍵（en + zh-TW）
- `4aaba48` test(tutorialStore): 補 dismissTutorial 寫 hasCompleted 測試（Bug 1 驗證）

## 自驗結果

### tsc / vitest / build
- npx tsc --noEmit: 0 errors
- npx vitest run: 411 passed / 35 test files（+3 dismiss 新測試）
- npx vite build: success

### localStorage 抽查（Playwright headless）

| 情境 | 預期 | 結果 |
|------|------|------|
| 清 localStorage 開局 → OnboardingPromptModal 出現 | visible | PASS |
| modal 出現時 localStorage.tutorialCompleted | null | PASS |
| 點「Skip for Now」後 localStorage.tutorialCompleted | "true" | PASS |
| 點「Skip for Now」後 modal 消失 | 消失 | PASS |
| 回訪玩家（tutorialCompleted=true）開局 modal | 0 次 | PASS |

## 安全雙審判斷

純 UI 層：不動 src/core/、不動 gameStore actions、不引新套件、無 DB 觸及