### PR TITLE
feat(ui): R+21 遊戲中途離開回主選單（含確認 modal）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { MultiplayerSetup } from './components/Game/MultiplayerSetup'
 import { MainMenu } from './components/Menu/MainMenu'
 import { TutorialOverlay } from './components/Tutorial/TutorialOverlay'
 import { OnboardingPromptModal } from './components/Tutorial/OnboardingPromptModal'
+import { QuitToMenuConfirmModal } from './components/Game/QuitToMenuConfirmModal'
 import { useTutorialStore } from './store/tutorialStore'
 import { TurnBanner } from './components/Game/TurnBanner'
 import { ObjectiveCardBadge } from './components/Game/ObjectiveCardBadge'
@@ -48,6 +49,7 @@ import {
   EndTurnIcon,
   UndoIcon,
   AchievementIcon,
+  ExitIcon,
 } from './components/icons'
 
 const STATE_BROADCAST_DEBOUNCE_MS = 50;
@@ -211,6 +213,9 @@ function App() {
 
   // More menu (Header ⋯ button)
   const [moreMenuOpen, setMoreMenuOpen] = useState(false)
+
+  // Quit-to-menu confirmation modal
+  const [quitConfirmOpen, setQuitConfirmOpen] = useState(false)
 
   const handleStart = (configs: PlayerConfig[], options: GameOptions, customBoard?: Board) => {
     initGame(configs, options, customBoard);
@@ -432,6 +437,14 @@ function App() {
     setGameStarted(false);
   };
 
+  const handleQuitToMenu = () => {
+    if (isNetworkGame) {
+      leaveRoom();
+    }
+    setMenuMode('home');
+    setGameStarted(false);
+  };
+
   const handleDrawTerrainCard = () => {
     runNetworkedAction(
       () => drawTerrainCard(),
@@ -638,16 +651,20 @@ function App() {
                 >
                   <button
                     role="menuitem"
-                    className="w-full text-left px-4 py-2.5 text-sm flex items-center gap-2 hover:bg-gray-100 transition"
+                    className="w-full text-left px-4 py-2.5 text-sm flex items-center gap-2 transition"
                     style={{ color: 'var(--color-text)' }}
+                    onMouseEnter={e => (e.currentTarget.style.backgroundColor = 'oklch(0 0 0 / 0.06)')}
+                    onMouseLeave={e => (e.currentTarget.style.backgroundColor = 'transparent')}
                     onClick={() => { setSeasonHistoryOpen(true); setMoreMenuOpen(false); }}
                   >
                     {t('season.open')}
                   </button>
                   <button
                     role="menuitem"
-                    className="w-full text-left px-4 py-2.5 text-sm flex items-center gap-2 hover:bg-gray-100 transition"
+                    className="w-full text-left px-4 py-2.5 text-sm flex items-center gap-2 transition"
                     style={{ color: 'var(--color-text)' }}
+                    onMouseEnter={e => (e.currentTarget.style.backgroundColor = 'oklch(0 0 0 / 0.06)')}
+                    onMouseLeave={e => (e.currentTarget.style.backgroundColor = 'transparent')}
                     onClick={() => { setLeaderboardOpen(true); setMoreMenuOpen(false); }}
                   >
                     <LeaderboardIcon size={16} />
@@ -655,8 +672,10 @@ function App() {
                   </button>
                   <button
                     role="menuitem"
-                    className="w-full text-left px-4 py-2.5 text-sm flex items-center gap-2 hover:bg-gray-100 transition"
+                    className="w-full text-left px-4 py-2.5 text-sm flex items-center gap-2 transition"
                     style={{ color: 'var(--color-text)' }}
+                    onMouseEnter={e => (e.currentTarget.style.backgroundColor = 'oklch(0 0 0 / 0.06)')}
+                    onMouseLeave={e => (e.currentTarget.style.backgroundColor = 'transparent')}
                     onClick={() => { setReplayOpen(true); setMoreMenuOpen(false); }}
                   >
                     <ReplayIcon size={16} />
@@ -664,8 +683,10 @@ function App() {
                   </button>
                   <button
                     role="menuitem"
-                    className="w-full text-left px-4 py-2.5 text-sm flex items-center gap-2 hover:bg-gray-100 transition"
+                    className="w-full text-left px-4 py-2.5 text-sm flex items-center gap-2 transition"
                     style={{ color: 'var(--color-text)' }}
+                    onMouseEnter={e => (e.currentTarget.style.backgroundColor = 'oklch(0 0 0 / 0.06)')}
+                    onMouseLeave={e => (e.currentTarget.style.backgroundColor = 'transparent')}
                     onClick={() => { setAchievementOpen(true); setMoreMenuOpen(false); }}
                   >
                     <AchievementIcon size={16} />
@@ -681,6 +702,24 @@ function App() {
                         {achievementUnlockedCount}
                       </span>
                     )}
+                  </button>
+                  {/* Divider */}
+                  <div
+                    role="separator"
+                    aria-hidden="true"
+                    style={{ borderTop: '1px solid var(--card-border)', margin: '4px 0' }}
+                  />
+                  {/* Quit to menu */}
+                  <button
+                    role="menuitem"
+                    className="w-full text-left px-4 py-2.5 text-sm flex items-center gap-2 transition"
+                    style={{ color: 'var(--color-wine-600)' }}
+                    onMouseEnter={e => (e.currentTarget.style.backgroundColor = 'oklch(0.95 0.01 30 / 0.08)')}
+                    onMouseLeave={e => (e.currentTarget.style.backgroundColor = 'transparent')}
+                    onClick={() => { setQuitConfirmOpen(true); setMoreMenuOpen(false); }}
+                  >
+                    <ExitIcon size={16} />
+                    {t('quitConfirm.title')}
                   </button>
                 </div>
               </>
@@ -1291,6 +1330,14 @@ function App() {
 
       {/* Achievement unlock toast notification */}
       <AchievementToast />
+
+      {/* Quit-to-menu confirmation modal */}
+      <QuitToMenuConfirmModal
+        isOpen={quitConfirmOpen}
+        isNetworkGame={isNetworkGame}
+        onConfirm={() => { setQuitConfirmOpen(false); handleQuitToMenu(); }}
+        onCancel={() => setQuitConfirmOpen(false)}
+      />
 
       {/* Onboarding prompt — shown to first-time players after game start */}
       <OnboardingPromptModal

--- a/src/components/Game/QuitToMenuConfirmModal.tsx
+++ b/src/components/Game/QuitToMenuConfirmModal.tsx
@@ -1,0 +1,124 @@
+import { useTranslation } from 'react-i18next';
+
+interface QuitToMenuConfirmModalProps {
+  isOpen: boolean;
+  isNetworkGame: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * QuitToMenuConfirmModal — shown when player clicks "Quit Game" from the more-menu
+ * during an active game session.
+ *
+ * Warns about progress loss (solo) or room departure (multiplayer) before confirming.
+ *
+ * Pattern: inline dialog, same as OnboardingPromptModal
+ * z-index: z-[52] — above more-menu backdrop (z-40) and menu panel (z-50),
+ *                    below tutorial overlay (z-[70])
+ */
+export function QuitToMenuConfirmModal({
+  isOpen,
+  isNetworkGame,
+  onConfirm,
+  onCancel,
+}: QuitToMenuConfirmModalProps) {
+  const { t } = useTranslation();
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        aria-hidden="true"
+        className="fixed inset-0 z-[51]"
+        style={{ backgroundColor: 'oklch(0 0 0 / 0.55)' }}
+      />
+
+      {/* Modal panel */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('quitConfirm.title')}
+        className="fixed inset-0 z-[52] flex items-center justify-center px-4"
+      >
+        <div
+          className="relative w-full max-w-sm rounded-[var(--radius-14)] overflow-hidden animate-modal-enter"
+          style={{
+            backgroundColor: 'var(--color-surface)',
+            boxShadow: 'var(--shadow-lifted)',
+            border: '1px solid var(--card-border)',
+          }}
+        >
+          {/* 4px wine accent rail */}
+          <div
+            aria-hidden="true"
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              bottom: 0,
+              width: 4,
+              backgroundColor: 'var(--color-wine-600)',
+              borderTopLeftRadius: 'var(--radius-14)',
+              borderBottomLeftRadius: 'var(--radius-14)',
+            }}
+          />
+
+          {/* Content */}
+          <div className="px-6 py-6" style={{ paddingLeft: '1.75rem' }}>
+            <h2
+              className="font-bold mb-3"
+              style={{
+                fontFamily: 'var(--font-display)',
+                fontSize: 'var(--type-display-sm)',
+                lineHeight: 'var(--line-height-display)',
+                color: 'var(--color-text)',
+              }}
+            >
+              {t('quitConfirm.title')}
+            </h2>
+
+            <p
+              className="mb-6 text-sm"
+              style={{
+                color: 'var(--color-stone-600)',
+                lineHeight: 'var(--line-height-body)',
+              }}
+            >
+              {isNetworkGame
+                ? t('quitConfirm.bodyMultiplayer')
+                : t('quitConfirm.bodySolo')}
+            </p>
+
+            {/* Buttons */}
+            <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+              <button
+                onClick={onCancel}
+                className="px-5 py-2.5 rounded-xl text-sm font-medium transition"
+                style={{
+                  border: '1px solid var(--card-border)',
+                  color: 'var(--color-stone-600)',
+                  backgroundColor: 'transparent',
+                }}
+              >
+                {t('quitConfirm.cancel')}
+              </button>
+              <button
+                onClick={onConfirm}
+                className="px-5 py-2.5 rounded-xl text-sm font-semibold transition"
+                style={{
+                  backgroundColor: 'var(--color-wine-600)',
+                  color: 'var(--button-text)',
+                }}
+              >
+                {t('quitConfirm.confirm')}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/icons/ExitIcon.tsx
+++ b/src/components/icons/ExitIcon.tsx
@@ -1,0 +1,25 @@
+import type { SVGProps } from 'react'
+
+export function ExitIcon({ size = 24, ...props }: { size?: number } & SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      {/* Door frame */}
+      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+      {/* Arrow pointing right (exit) */}
+      <polyline points="16 17 21 12 16 7" />
+      <line x1="21" y1="12" x2="9" y2="12" />
+    </svg>
+  )
+}

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -41,6 +41,7 @@ export { ChevronIcon } from './ChevronIcon'
 export { MenuIcon } from './MenuIcon'
 export { MoreIcon } from './MoreIcon'
 export { SearchIcon } from './SearchIcon'
+export { ExitIcon } from './ExitIcon'
 
 // Wrapper component
 export { Icon } from './Icon'

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -467,6 +467,13 @@ export const en = {
       },
     },
   },
+  quitConfirm: {
+    title: 'Quit Game?',
+    bodySolo: 'Your current progress will not be saved.',
+    bodyMultiplayer: 'You will leave the room. Other players will continue without you.',
+    confirm: 'Leave Game',
+    cancel: 'Keep Playing',
+  },
   mapEditor: {
     title: 'Map Editor',
     subtitle: 'Design your custom map',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -465,6 +465,13 @@ export const zhTW = {
       },
     },
   },
+  quitConfirm: {
+    title: '離開遊戲？',
+    bodySolo: '目前遊戲進度不會保存。',
+    bodyMultiplayer: '你將離開房間，其他玩家將繼續遊戲。',
+    confirm: '離開遊戲',
+    cancel: '繼續遊戲',
+  },
   mapEditor: {
     title: '地圖編輯器',
     subtitle: '設計你的自訂地圖',


### PR DESCRIPTION
## 計劃連結

/tmp/kingdom-builder-r21-plan-2026-06-03.md（CPO Gray, 2026-06-03）

## 異動摘要

遊戲進行中缺少離開入口，玩家只能玩完或重整瀏覽器。本 PR 在 more-menu 加入「離開遊戲」入口與確認 modal，回主選單大廳。

## Commit List

- `d299003` feat(icons): add ExitIcon (door-with-arrow, Lucide style)
- `193f1f2` feat(ui): add QuitToMenuConfirmModal component
- `1b86d49` feat(app): R+21 quit-to-menu handler, state, modal mount
- `b81fdc3` feat(i18n): add quitConfirm key group (en + zh-TW)

## 修改範圍

| 檔案 | 說明 |
|------|------|
| `src/components/icons/ExitIcon.tsx` | 新增 door-with-arrow SVG icon（Lucide 風格，24x24，1.5px stroke） |
| `src/components/icons/index.ts` | export ExitIcon |
| `src/components/Game/QuitToMenuConfirmModal.tsx` | 新增確認 modal（z-[52]，4px wine rail，animate-modal-enter） |
| `src/i18n/locales/en.ts` | 新增 quitConfirm key group |
| `src/i18n/locales/zh-TW.ts` | 新增 quitConfirm key group |
| `src/App.tsx` | handleQuitToMenu handler、quitConfirmOpen state、more-menu 第5項、modal 掛載、hover token 化 |

## 自驗結果

- `npx tsc --noEmit`: 0 errors
- `npx vitest run`: 411/411 passed
- `npx vite build`: 成功（warning 為既有 pre-existing）
- vite preview + Playwright 截圖確認：
  - Screenshot 03: more-menu 5 項，底部分隔線，「Quit Game?」酒紅色
  - Screenshot 04: 確認 modal（標題 Quit Game?，說明 solo 版，Keep Playing / Leave Game）
  - Screenshot 05: 取消後遊戲正常繼續
  - Screenshot 06: 確認後回主選單（gameStarted=false, menuMode=home）

截圖路徑：`/tmp/r21-03-moremenu.png`、`/tmp/r21-04-confirmmodal.png`、`/tmp/r21-05-aftercancel.png`、`/tmp/r21-06-mainmenu-after-quit.png`

## handleRestart 未動確認

`handleRestart`（App.tsx:425-433）原樣未動：單機→setup、多人→leaveRoom+multiplayer，與 handleQuitToMenu（→home）語意完全獨立。

## 安全雙審判斷

純 UI 層新增，未動 src/core/、gameStore 內部、multiplayerStore 內部、handleRestart、scoring。不需要雙審。

## Reviewer

@cancleeric (CEO Nicholas)