### PR TITLE
fix(ux): R+22 存檔/續玩正確性（quit 文案校準 + 開新局覆蓋警告）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import { MainMenu } from './components/Menu/MainMenu'
 import { TutorialOverlay } from './components/Tutorial/TutorialOverlay'
 import { OnboardingPromptModal } from './components/Tutorial/OnboardingPromptModal'
 import { QuitToMenuConfirmModal } from './components/Game/QuitToMenuConfirmModal'
+import { NewGameOverwriteConfirmModal } from './components/Game/NewGameOverwriteConfirmModal'
+import { loadGame } from './store/persistence'
 import { useTutorialStore } from './store/tutorialStore'
 import { TurnBanner } from './components/Game/TurnBanner'
 import { ObjectiveCardBadge } from './components/Game/ObjectiveCardBadge'
@@ -130,6 +132,12 @@ function App() {
   const [achievementOpen, setAchievementOpen] = useState(false);
   const [seasonHistoryOpen, setSeasonHistoryOpen] = useState(false);
   const [showOnboardingPrompt, setShowOnboardingPrompt] = useState(false);
+  const [newGameConfirmOpen, setNewGameConfirmOpen] = useState(false);
+  const pendingStartRef = useRef<{
+    configs: PlayerConfig[];
+    options: GameOptions;
+    customBoard?: Board;
+  } | null>(null);
   const broadcastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const submittedGameKeyRef = useRef<string | null>(null);
 
@@ -217,7 +225,7 @@ function App() {
   // Quit-to-menu confirmation modal
   const [quitConfirmOpen, setQuitConfirmOpen] = useState(false)
 
-  const handleStart = (configs: PlayerConfig[], options: GameOptions, customBoard?: Board) => {
+  const _doStartGame = (configs: PlayerConfig[], options: GameOptions, customBoard?: Board) => {
     initGame(configs, options, customBoard);
     setGameStarted(true);
     // First-time player onboarding prompt (single player only)
@@ -225,6 +233,32 @@ function App() {
     if (!hasCompleted && !isNetworkGame) {
       setShowOnboardingPrompt(true);
     }
+  };
+
+  const handleStart = (configs: PlayerConfig[], options: GameOptions, customBoard?: Board) => {
+    // Guard: if a save exists, require confirmation before overwriting
+    // (only single-player new game goes through handleStart;
+    //  continue-game and multiplayer bypass this entirely)
+    if (loadGame() !== null) {
+      pendingStartRef.current = { configs, options, customBoard };
+      setNewGameConfirmOpen(true);
+      return;
+    }
+    _doStartGame(configs, options, customBoard);
+  };
+
+  const handleNewGameConfirm = () => {
+    setNewGameConfirmOpen(false);
+    if (pendingStartRef.current) {
+      const { configs, options, customBoard } = pendingStartRef.current;
+      pendingStartRef.current = null;
+      _doStartGame(configs, options, customBoard);
+    }
+  };
+
+  const handleNewGameCancel = () => {
+    setNewGameConfirmOpen(false);
+    pendingStartRef.current = null;
   };
 
   const handleToggleMute = () => {
@@ -1337,6 +1371,13 @@ function App() {
         isNetworkGame={isNetworkGame}
         onConfirm={() => { setQuitConfirmOpen(false); handleQuitToMenu(); }}
         onCancel={() => setQuitConfirmOpen(false)}
+      />
+
+      {/* New-game overwrite confirmation modal */}
+      <NewGameOverwriteConfirmModal
+        isOpen={newGameConfirmOpen}
+        onConfirm={handleNewGameConfirm}
+        onCancel={handleNewGameCancel}
       />
 
       {/* Onboarding prompt — shown to first-time players after game start */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -556,6 +556,12 @@ function App() {
             onBack={() => setMenuMode('home')}
           />
           <TutorialOverlay />
+          {/* New-game overwrite confirmation — rendered here because game hasn't started yet */}
+          <NewGameOverwriteConfirmModal
+            isOpen={newGameConfirmOpen}
+            onConfirm={handleNewGameConfirm}
+            onCancel={handleNewGameCancel}
+          />
         </>
       );
     }

--- a/src/components/Game/NewGameOverwriteConfirmModal.tsx
+++ b/src/components/Game/NewGameOverwriteConfirmModal.tsx
@@ -1,0 +1,117 @@
+import { useTranslation } from 'react-i18next';
+
+interface NewGameOverwriteConfirmModalProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * NewGameOverwriteConfirmModal — shown when player tries to start a new single-player
+ * game while an existing save is present.
+ *
+ * Pattern: mirrors QuitToMenuConfirmModal (same design tokens, same z-index tier)
+ * z-index: z-[52] — above more-menu backdrop (z-40) and menu panel (z-50)
+ */
+export function NewGameOverwriteConfirmModal({
+  isOpen,
+  onConfirm,
+  onCancel,
+}: NewGameOverwriteConfirmModalProps) {
+  const { t } = useTranslation();
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        aria-hidden="true"
+        className="fixed inset-0 z-[51]"
+        style={{ backgroundColor: 'oklch(0 0 0 / 0.55)' }}
+      />
+
+      {/* Modal panel */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('newGameOverwrite.title')}
+        className="fixed inset-0 z-[52] flex items-center justify-center px-4"
+      >
+        <div
+          className="relative w-full max-w-sm rounded-[var(--radius-14)] overflow-hidden animate-modal-enter"
+          style={{
+            backgroundColor: 'var(--color-surface)',
+            boxShadow: 'var(--shadow-lifted)',
+            border: '1px solid var(--card-border)',
+          }}
+        >
+          {/* 4px wine accent rail */}
+          <div
+            aria-hidden="true"
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              bottom: 0,
+              width: 4,
+              backgroundColor: 'var(--color-wine-600)',
+              borderTopLeftRadius: 'var(--radius-14)',
+              borderBottomLeftRadius: 'var(--radius-14)',
+            }}
+          />
+
+          {/* Content */}
+          <div className="px-6 py-6" style={{ paddingLeft: '1.75rem' }}>
+            <h2
+              className="font-bold mb-3"
+              style={{
+                fontFamily: 'var(--font-display)',
+                fontSize: 'var(--type-display-sm)',
+                lineHeight: 'var(--line-height-display)',
+                color: 'var(--color-text)',
+              }}
+            >
+              {t('newGameOverwrite.title')}
+            </h2>
+
+            <p
+              className="mb-6 text-sm"
+              style={{
+                color: 'var(--color-stone-600)',
+                lineHeight: 'var(--line-height-body)',
+              }}
+            >
+              {t('newGameOverwrite.body')}
+            </p>
+
+            {/* Buttons */}
+            <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+              <button
+                onClick={onCancel}
+                className="px-5 py-2.5 rounded-xl text-sm font-medium transition"
+                style={{
+                  border: '1px solid var(--card-border)',
+                  color: 'var(--color-stone-600)',
+                  backgroundColor: 'transparent',
+                }}
+              >
+                {t('newGameOverwrite.cancel')}
+              </button>
+              <button
+                onClick={onConfirm}
+                className="px-5 py-2.5 rounded-xl text-sm font-semibold transition"
+                style={{
+                  backgroundColor: 'var(--color-wine-600)',
+                  color: 'var(--button-text)',
+                }}
+              >
+                {t('newGameOverwrite.confirm')}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -469,7 +469,7 @@ export const en = {
   },
   quitConfirm: {
     title: 'Quit Game?',
-    bodySolo: 'Your current progress will not be saved.',
+    bodySolo: 'You can continue this game anytime from the main menu.',
     bodyMultiplayer: 'You will leave the room. Other players will continue without you.',
     confirm: 'Leave Game',
     cancel: 'Keep Playing',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -474,6 +474,12 @@ export const en = {
     confirm: 'Leave Game',
     cancel: 'Keep Playing',
   },
+  newGameOverwrite: {
+    title: 'Start a New Game?',
+    body: 'You have a game in progress. Starting a new game will overwrite your saved progress and it cannot be recovered.',
+    confirm: 'Start New Game',
+    cancel: 'Go Back',
+  },
   mapEditor: {
     title: 'Map Editor',
     subtitle: 'Design your custom map',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -472,6 +472,12 @@ export const zhTW = {
     confirm: '離開遊戲',
     cancel: '繼續遊戲',
   },
+  newGameOverwrite: {
+    title: '開始新遊戲？',
+    body: '你有一局進行中的遊戲。開始新局將覆蓋現有存檔，舊局無法恢復。',
+    confirm: '開始新局',
+    cancel: '返回',
+  },
   mapEditor: {
     title: '地圖編輯器',
     subtitle: '設計你的自訂地圖',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -467,7 +467,7 @@ export const zhTW = {
   },
   quitConfirm: {
     title: '離開遊戲？',
-    bodySolo: '目前遊戲進度不會保存。',
+    bodySolo: '你可以隨時從主選單繼續這局遊戲。',
     bodyMultiplayer: '你將離開房間，其他玩家將繼續遊戲。',
     confirm: '離開遊戲',
     cancel: '繼續遊戲',


### PR DESCRIPTION
## 計劃連結

/tmp/kingdom-builder-r22-plan-2026-06-03.md（R+22 CPO 計劃書，CEO 核准）

## 改動摘要

**缺口 1：quit 文案校準**
- \`quitConfirm.bodySolo\` 舊文案謊稱「不會保存」，實際 autosave 持續有效
- 更新 en + zh-TW，bodyMultiplayer 不動

**缺口 2：開新局覆蓋警告**
- 有存檔時從 GameSetup 點「開始遊戲」會靜默覆蓋存檔
- \`handleStart\` 拆成 guard + \`_doStartGame\`，有存檔時彈 \`NewGameOverwriteConfirmModal\`
- 確認 → 新局開始；取消 → 留在 GameSetup，舊存檔完整保留
- 多人/續玩路徑不走 \`handleStart\`，不受影響

## Commit List

- \`64e8a58\` i18n(quit): 校準 bodySolo 文案，反映自動存檔行為
- \`79a35fe\` feat(ui): 新增 NewGameOverwriteConfirmModal 元件
- \`2b15c46\` feat(ux): App.tsx handleStart 拆分 + 開新局覆蓋警告
- \`1d89edb\` i18n(overwrite): 新增 newGameOverwrite key group（en + zh-TW）
- \`9e6439a\` fix(ux): NewGameOverwriteConfirmModal 掛載到 setup return 分支

## 自驗結果（vite dev + Playwright）

| 情境 | 結果 |
|------|------|
| Scenario 1：quit 文案顯示「可從主選單繼續」 | PASS |
| Scenario 2：有存檔開新局 → 覆蓋警告彈出 | PASS |
| Scenario 2b：確認 → 新局正常開始 | PASS |
| Scenario 3：取消 → 留 GameSetup，存檔保留 | PASS |
| Scenario 4：無存檔開新局 → 直接開局無警告 | PASS |

tsc: 0 error | vitest: 411 passed (35 files) | vite build: success

## 技術邊界

- 純 UI 層：App.tsx（UI controller）、i18n 文字、新 modal 元件
- 未動：src/core/、gameStore actions、多人/續玩路徑、scoring
- 設計 token 複用 QuitToMenuConfirmModal（wine rail、--radius-14、--shadow-lifted）

## Reviewer

@cancleeric（CEO 親驗）

🤖 Generated with [Claude Code](https://claude.com/claude-code)