### PR TITLE
style(ui): R+23 Replay 系列設計 token sweep（4 元件 + v3 語法修）

### DIFF
--- a/src/components/Game/ReplayList.tsx
+++ b/src/components/Game/ReplayList.tsx
@@ -16,7 +16,14 @@ export const ReplayList = React.memo(function ReplayList({
   const { t } = useTranslation();
 
   if (replays.length === 0) {
-    return <p className="text-gray-500 text-sm text-center py-4">{t('replay.empty')}</p>;
+    return (
+      <p
+        className="text-sm text-center py-4"
+        style={{ color: 'var(--color-stone-500)' }}
+      >
+        {t('replay.empty')}
+      </p>
+    );
   }
 
   return (
@@ -26,14 +33,20 @@ export const ReplayList = React.memo(function ReplayList({
         return (
           <li
             key={replay.id}
-            className="border rounded-lg p-3 flex flex-col gap-2 bg-white hover:bg-gray-50 transition"
+            className="rounded-lg p-3 flex flex-col gap-2 transition"
+            style={{
+              background: 'var(--color-surface)',
+              border: '1px solid var(--card-border)',
+            }}
+            onMouseEnter={e => (e.currentTarget.style.background = 'var(--color-warm-cream-200)')}
+            onMouseLeave={e => (e.currentTarget.style.background = 'var(--color-surface)')}
           >
             <div className="flex items-start justify-between gap-2">
               <div className="min-w-0">
                 <p className="font-semibold text-sm truncate">
                   {t('replay.winner', { name: replay.winnerName })}
                 </p>
-                <p className="text-xs text-gray-500">{dateLabel}</p>
+                <p className="text-xs" style={{ color: 'var(--color-stone-500)' }}>{dateLabel}</p>
                 <div className="flex flex-wrap gap-1 mt-1">
                   {replay.players.map((p) => (
                     <span
@@ -42,8 +55,8 @@ export const ReplayList = React.memo(function ReplayList({
                       style={{ borderColor: p.color }}
                     >
                       <span
-                        className="w-2 h-2 rounded-full inline-block border border-gray-600"
-                        style={{ backgroundColor: p.color }}
+                        className="w-2 h-2 rounded-full inline-block border"
+                        style={{ backgroundColor: p.color, borderColor: 'var(--color-stone-600)' }}
                         aria-hidden="true"
                       />
                       {p.name}
@@ -54,21 +67,34 @@ export const ReplayList = React.memo(function ReplayList({
               <div className="flex flex-col gap-1 shrink-0">
                 <button
                   onClick={() => onSelect(replay.id)}
-                  className="text-xs bg-blue-600 hover:bg-blue-700 text-white font-medium py-1 px-3 rounded transition"
+                  className="text-xs font-medium py-1 px-3 rounded transition"
+                  style={{
+                    background: 'var(--button-primary-bg)',
+                    color: 'var(--button-text)',
+                  }}
+                  onMouseEnter={e => (e.currentTarget.style.background = 'var(--button-primary-bg-hover)')}
+                  onMouseLeave={e => (e.currentTarget.style.background = 'var(--button-primary-bg)')}
                   aria-label={`${t('replay.viewReplay')} – ${dateLabel}`}
                 >
                   {t('replay.viewReplay')}
                 </button>
                 <button
                   onClick={() => onDelete(replay.id)}
-                  className="text-xs bg-white hover:bg-red-50 text-red-500 border border-red-300 font-medium py-1 px-3 rounded transition"
+                  className="text-xs font-medium py-1 px-3 rounded transition border"
+                  style={{
+                    background: 'var(--color-surface)',
+                    color: 'var(--color-danger)',
+                    borderColor: 'var(--color-danger)',
+                  }}
+                  onMouseEnter={e => (e.currentTarget.style.background = 'oklch(0.95 0.02 20 / 0.15)')}
+                  onMouseLeave={e => (e.currentTarget.style.background = 'var(--color-surface)')}
                   aria-label={`${t('replay.deleteReplay')} – ${dateLabel}`}
                 >
                   {t('replay.deleteReplay')}
                 </button>
               </div>
             </div>
-            <p className="text-xs text-gray-400">
+            <p className="text-xs" style={{ color: 'var(--color-stone-400)' }}>
               {t('replay.actionCount', { count: replay.history.length })}
             </p>
           </li>

--- a/src/components/Game/ReplayViewer.tsx
+++ b/src/components/Game/ReplayViewer.tsx
@@ -75,7 +75,10 @@ export const ReplayViewer = React.memo(function ReplayViewer({ replay, onBack }:
       <div className="flex items-center gap-3 mb-4">
         <button
           onClick={onBack}
-          className="text-sm text-blue-600 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+          className="text-sm hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+          style={{ color: 'var(--color-wine-600)', outlineColor: 'var(--color-wine-600)' }}
+          onMouseEnter={e => (e.currentTarget.style.color = 'var(--color-wine-700)')}
+          onMouseLeave={e => (e.currentTarget.style.color = 'var(--color-wine-600)')}
           aria-label={t('replay.backToList')}
         >
           {t('replay.backToList')}
@@ -84,8 +87,19 @@ export const ReplayViewer = React.memo(function ReplayViewer({ replay, onBack }:
       </div>
 
       {/* Winner & players summary */}
-      <div className="mb-4 p-3 bg-amber-50 border border-amber-200 rounded-lg">
-        <p className="font-semibold text-amber-800 mb-1">{t('replay.winner', { name: replay.winnerName })}</p>
+      <div
+        className="mb-4 p-3 rounded-lg border"
+        style={{
+          background: 'var(--color-amber-100)',
+          borderColor: 'var(--color-amber-700)',
+        }}
+      >
+        <p
+          className="font-semibold mb-1"
+          style={{ color: 'var(--color-amber-700)' }}
+        >
+          {t('replay.winner', { name: replay.winnerName })}
+        </p>
         <div className="flex flex-wrap gap-2">
           {players.map((p) => (
             <span
@@ -94,8 +108,8 @@ export const ReplayViewer = React.memo(function ReplayViewer({ replay, onBack }:
               style={{ borderColor: p.color }}
             >
               <span
-                className="w-2.5 h-2.5 rounded-full inline-block border border-gray-600"
-                style={{ backgroundColor: p.color }}
+                className="w-2.5 h-2.5 rounded-full inline-block border"
+                style={{ backgroundColor: p.color, borderColor: 'var(--color-stone-600)' }}
                 aria-hidden="true"
               />
               {p.name}
@@ -105,29 +119,33 @@ export const ReplayViewer = React.memo(function ReplayViewer({ replay, onBack }:
       </div>
 
       {total === 0 ? (
-        <p className="text-gray-500 text-sm">{t('replay.noActions')}</p>
+        <p className="text-sm" style={{ color: 'var(--color-stone-500)' }}>{t('replay.noActions')}</p>
       ) : (
         <>
           {/* Step counter */}
-          <p className="text-sm text-gray-500 mb-2 text-center">
+          <p className="text-sm mb-2 text-center" style={{ color: 'var(--color-stone-500)' }}>
             {t('replay.stepOf', { current: stepIndex + 1, total })}
           </p>
 
           {/* Current action card */}
           {currentAction && (
             <div
-              className="mb-4 p-4 bg-white border-2 rounded-lg shadow-sm"
-              style={{ borderColor: getPlayerColor(currentAction.playerId) }}
+              className="mb-4 p-4 border-2 rounded-lg"
+              style={{
+                background: 'var(--color-surface)',
+                boxShadow: 'var(--shadow-soft)',
+                borderColor: getPlayerColor(currentAction.playerId),
+              }}
               aria-live="polite"
               aria-atomic="true"
             >
-              <p className="text-xs text-gray-500 mb-1">
+              <p className="text-xs mb-1" style={{ color: 'var(--color-stone-500)' }}>
                 {t('replay.actionTurn', { turn: currentAction.turnNumber })}
               </p>
               <p className="font-semibold text-base mb-1">
                 {t('replay.actionPlayer', { player: getPlayerName(currentAction.playerId) })}
               </p>
-              <p className="text-sm text-gray-700">
+              <p className="text-sm" style={{ color: 'var(--color-stone-700)' }}>
                 {describeAction(t, currentAction)}
               </p>
             </div>
@@ -138,11 +156,31 @@ export const ReplayViewer = React.memo(function ReplayViewer({ replay, onBack }:
             <button
               onClick={goPrev}
               disabled={stepIndex === 0}
-              className={`flex-1 py-2 px-4 rounded font-semibold text-sm transition border ${
+              className="flex-1 py-2 px-4 rounded font-semibold text-sm transition border"
+              style={
                 stepIndex === 0
-                  ? 'bg-gray-100 text-gray-400 border-gray-300 cursor-not-allowed'
-                  : 'bg-white hover:bg-gray-50 text-blue-600 border-blue-400'
-              }`}
+                  ? {
+                      background: 'var(--color-warm-cream-200)',
+                      color: 'var(--color-stone-400)',
+                      borderColor: 'var(--card-border)',
+                      cursor: 'not-allowed',
+                    }
+                  : {
+                      background: 'var(--color-surface)',
+                      color: 'var(--color-wine-600)',
+                      borderColor: 'var(--color-wine-600)',
+                    }
+              }
+              onMouseEnter={e => {
+                if (stepIndex !== 0) {
+                  e.currentTarget.style.background = 'var(--color-warm-cream-200)';
+                }
+              }}
+              onMouseLeave={e => {
+                if (stepIndex !== 0) {
+                  e.currentTarget.style.background = 'var(--color-surface)';
+                }
+              }}
               aria-label={t('replay.previous')}
             >
               {t('replay.previous')}
@@ -150,11 +188,31 @@ export const ReplayViewer = React.memo(function ReplayViewer({ replay, onBack }:
             <button
               onClick={goNext}
               disabled={stepIndex === total - 1}
-              className={`flex-1 py-2 px-4 rounded font-semibold text-sm transition border ${
+              className="flex-1 py-2 px-4 rounded font-semibold text-sm transition border"
+              style={
                 stepIndex === total - 1
-                  ? 'bg-gray-100 text-gray-400 border-gray-300 cursor-not-allowed'
-                  : 'bg-blue-600 hover:bg-blue-700 text-white border-blue-600'
-              }`}
+                  ? {
+                      background: 'var(--color-warm-cream-200)',
+                      color: 'var(--color-stone-400)',
+                      borderColor: 'var(--card-border)',
+                      cursor: 'not-allowed',
+                    }
+                  : {
+                      background: 'var(--button-primary-bg)',
+                      color: 'var(--button-text)',
+                      borderColor: 'var(--color-wine-600)',
+                    }
+              }
+              onMouseEnter={e => {
+                if (stepIndex !== total - 1) {
+                  e.currentTarget.style.background = 'var(--button-primary-bg-hover)';
+                }
+              }}
+              onMouseLeave={e => {
+                if (stepIndex !== total - 1) {
+                  e.currentTarget.style.background = 'var(--button-primary-bg)';
+                }
+              }}
               aria-label={t('replay.next')}
             >
               {t('replay.next')}
@@ -172,22 +230,41 @@ export const ReplayViewer = React.memo(function ReplayViewer({ replay, onBack }:
                   <li key={idx}>
                     <button
                       onClick={() => setStepIndex(idx)}
-                      className={`w-full text-left flex items-start gap-2 p-2 rounded text-sm transition ${
-                        isActive ? 'bg-blue-50 border border-blue-300' : 'hover:bg-gray-50 border border-transparent'
-                      }`}
+                      className="w-full text-left flex items-start gap-2 p-2 rounded text-sm transition border"
+                      style={
+                        isActive
+                          ? {
+                              background: 'var(--color-warm-cream-200)',
+                              borderColor: 'var(--card-border)',
+                            }
+                          : {
+                              background: 'transparent',
+                              borderColor: 'transparent',
+                            }
+                      }
+                      onMouseEnter={e => {
+                        if (!isActive) {
+                          e.currentTarget.style.background = 'var(--color-warm-cream-200)';
+                        }
+                      }}
+                      onMouseLeave={e => {
+                        if (!isActive) {
+                          e.currentTarget.style.background = 'transparent';
+                        }
+                      }}
                       aria-current={isActive ? 'true' : undefined}
                     >
                       <span
-                        className="w-2.5 h-2.5 rounded-full mt-0.5 shrink-0 border border-gray-600"
-                        style={{ backgroundColor: pColor }}
+                        className="w-2.5 h-2.5 rounded-full mt-0.5 shrink-0 border"
+                        style={{ backgroundColor: pColor, borderColor: 'var(--color-stone-600)' }}
                         aria-hidden="true"
                       />
                       <span className="flex-1 min-w-0">
                         <span className="font-medium">{pName}</span>
-                        <span className="text-gray-500 text-xs ml-2">
+                        <span className="text-xs ml-2" style={{ color: 'var(--color-stone-500)' }}>
                           {t('replay.actionTurn', { turn: action.turnNumber })}
                         </span>
-                        <span className="block text-gray-600 truncate">
+                        <span className="block truncate" style={{ color: 'var(--color-stone-600)' }}>
                           {describeAction(t, action)}
                         </span>
                       </span>
@@ -201,7 +278,10 @@ export const ReplayViewer = React.memo(function ReplayViewer({ replay, onBack }:
       )}
 
       {/* Final scores */}
-      <div className="mt-4 pt-4 border-t border-gray-200">
+      <div
+        className="mt-4 pt-4 border-t"
+        style={{ borderTopColor: 'var(--card-border)' }}
+      >
         <h4 className="text-sm font-semibold mb-2">{t('replay.finalScores')}</h4>
         <div className="space-y-1">
           {[...finalScores]
@@ -217,8 +297,8 @@ export const ReplayViewer = React.memo(function ReplayViewer({ replay, onBack }:
                 >
                   <span className="flex items-center gap-1.5">
                     <span
-                      className="w-2.5 h-2.5 rounded-full inline-block border border-gray-600 shrink-0"
-                      style={{ backgroundColor: pColor }}
+                      className="w-2.5 h-2.5 rounded-full inline-block border shrink-0"
+                      style={{ backgroundColor: pColor, borderColor: 'var(--color-stone-600)' }}
                       aria-hidden="true"
                     />
                     {pName}
@@ -235,7 +315,11 @@ export const ReplayViewer = React.memo(function ReplayViewer({ replay, onBack }:
         {objectiveCards.length > 0 && (
           <div className="mt-2 flex flex-wrap gap-1">
             {objectiveCards.map((card) => (
-              <span key={card} className="px-2 py-0.5 bg-blue-100 text-blue-800 text-xs rounded-full">
+              <span
+                key={card}
+                className="px-2 py-0.5 text-xs rounded-full"
+                style={{ background: 'var(--color-amber-100)', color: 'var(--color-amber-700)' }}
+              >
                 {tObjective(t, card)}
               </span>
             ))}

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -34,7 +34,14 @@ export function InstallPrompt() {
     <div className="fixed top-0 left-0 right-0 flex justify-center z-50 p-2">
       <button
         onClick={handleInstall}
-        className="bg-yellow-600 hover:bg-yellow-500 text-white font-semibold px-4 py-2 rounded-lg shadow-lg transition-colors"
+        className="font-semibold px-4 py-2 rounded-lg transition-colors"
+        style={{
+          background: 'var(--button-primary-bg)',
+          color: 'var(--button-text)',
+          boxShadow: 'var(--shadow-lifted)',
+        }}
+        onMouseEnter={e => (e.currentTarget.style.background = 'var(--button-primary-bg-hover)')}
+        onMouseLeave={e => (e.currentTarget.style.background = 'var(--button-primary-bg)')}
         aria-label={t('installPrompt.ariaLabel')}
       >
         {t('installPrompt.button')}

--- a/src/components/SaveLoadUI.tsx
+++ b/src/components/SaveLoadUI.tsx
@@ -31,7 +31,13 @@ export function SaveLoadUI({ onGameLoaded }: SaveLoadUIProps) {
       {hasSave && (
         <button
           onClick={handleContinue}
-          className="w-full bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded transition"
+          className="w-full font-bold py-2 px-4 rounded transition"
+          style={{
+            background: 'var(--button-secondary-bg)',
+            color: 'var(--button-text)',
+          }}
+          onMouseEnter={e => (e.currentTarget.style.background = 'var(--button-secondary-bg-hover)')}
+          onMouseLeave={e => (e.currentTarget.style.background = 'var(--button-secondary-bg)')}
         >
           {t('saveLoad.continueGame')}
         </button>
@@ -39,7 +45,13 @@ export function SaveLoadUI({ onGameLoaded }: SaveLoadUIProps) {
       {hasSave && (
         <button
           onClick={handleNewGame}
-          className="w-full bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded transition"
+          className="w-full font-bold py-2 px-4 rounded transition"
+          style={{
+            background: 'var(--button-primary-bg)',
+            color: 'var(--button-text)',
+          }}
+          onMouseEnter={e => (e.currentTarget.style.background = 'var(--button-primary-bg-hover)')}
+          onMouseLeave={e => (e.currentTarget.style.background = 'var(--button-primary-bg)')}
         >
           {t('saveLoad.newGame')}
         </button>
@@ -47,7 +59,14 @@ export function SaveLoadUI({ onGameLoaded }: SaveLoadUIProps) {
       {hasSave && (
         <button
           onClick={handleClearSave}
-          className="w-full font-bold py-2 px-4 rounded transition border bg-red-100 hover:bg-red-200 text-red-700 border-red-300"
+          className="w-full font-bold py-2 px-4 rounded transition border"
+          style={{
+            background: 'oklch(0.95 0.02 20 / 0.25)',
+            color: 'var(--color-wine-700)',
+            borderColor: 'var(--color-danger)',
+          }}
+          onMouseEnter={e => (e.currentTarget.style.background = 'oklch(0.90 0.03 20 / 0.4)')}
+          onMouseLeave={e => (e.currentTarget.style.background = 'oklch(0.95 0.02 20 / 0.25)')}
         >
           {t('saveLoad.clearSave')}
         </button>


### PR DESCRIPTION
## 計劃

[R23 計劃文件](/tmp/kingdom-builder-r23-plan-2026-06-03.md)（R19 續輪，CPO Gray 2026-06-03）

## 改動範圍

純 CSS/Tailwind token 替換 + onMouseEnter/Leave inline，不動 src/core/、gameStore、scoring、multiplayer。

## Commit 清單

- `7b7ee0c` style(ui): R+23 ReplayViewer 設計 token sweep（14 處 + v3 語法修）
- `8701932` style(ui): R+23 ReplayList 設計 token sweep（6 處 + v3 語法修）
- `f12b6ca` style(ui): R+23 SaveLoadUI 設計 token sweep（3 處 + v3 語法修）
- `4912348` style(ui): R+23 InstallPrompt 設計 token sweep（1 處 + v3 語法修）

## 改動明細

| 元件 | 改動 | v3 語法修 |
|------|------|----------|
| ReplayViewer | 14 處：返回鈕/勝者卡/動作卡/導航鈕/時間軸/分數/badge | 5 處 hover + 1 處 focus-visible |
| ReplayList | 6 處：空提示/卡片/日期/圓點邊/觀看鈕/刪除鈕/計數 | 3 處 hover |
| SaveLoadUI | 3 處：繼續/新遊戲/清除存檔 | 3 處 hover |
| InstallPrompt | 1 處：安裝 CTA 按鈕 | 1 處 hover |

## 自驗結果

- `npx tsc --noEmit`: 0 error
- `npx vitest run`: 411 passed (35 suites) — ReplayViewer.test / persistence.test 全過，無 regression
- `npx vite build`: 成功，498 kB bundle（warning 為 pre-existing replayStore dynamic import，非本次引入）

## 保留色確認

ReplayViewer 玩家語意色全數保留，未誤改：

- `p.color`（玩家圓點 backgroundColor + 標籤 borderColor）— L108、L112
- `getPlayerColor(currentAction.playerId)`（動作卡高亮 borderColor）— L137
- `pColor`（時間軸圓點 backgroundColor）— L259
- `pColor`（最終分數行 borderColor）— L296、L301
- ReplayList `p.color`（玩家標籤 borderColor + 圓點 backgroundColor）— 全數保留

grep 確認目標通用色清零（bg-blue/bg-white/text-gray/bg-green-6/bg-yellow-6/bg-red-1/hover:bg-*/focus-visible:outline-blue 在四個目標檔案中全部消除）。

## 安全雙審判斷

純 CSS/Tailwind token 替換，無 DB / gameStore action / 外部 API / src/core/ 異動，無新套件引入。**不觸發雙審**。

請 CEO 依計劃 Step 7 執行 vite preview 目視驗收 + Chrome MCP getComputedStyle 抽查。

Reviewer: @cancleeric