### PR TITLE
feat(R24-C): 棋盤環境框 — 深胡桃木桌 + 羊皮紙框 + 銅角扣 + 落地陰影 + 羅盤底紋

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import { AchievementToast } from './components/Game/AchievementToast'
 import { useAchievementStore, getUnlockedCount } from './store/achievementStore'
 import { SeasonBanner } from './components/Game/SeasonBanner'
 import { SeasonHistory } from './components/Game/SeasonHistory'
+import { BoardFrameOverlay } from './components/Board/BoardFrameOverlay'
 import { useSeasonStore } from './store/seasonStore'
 import { MapEditorPage } from './components/MapEditor/MapEditorPage'
 import {
@@ -791,7 +792,13 @@ function App() {
           )}
 
           {/* HexGrid */}
-          <div className="flex-1 relative overflow-hidden" style={{ boxShadow: 'var(--shadow-medium)' }}>
+          <div
+            className="flex-1 relative overflow-hidden"
+            style={{
+              background: 'var(--board-bg-light)',
+              boxShadow: 'var(--board-frame-shadow)',
+            }}
+          >
             {players.length > 0 && (
               <div className="w-full h-full" data-tutorial-target="hex-grid">
               <HexGrid
@@ -810,6 +817,8 @@ function App() {
               />
               </div>
             )}
+            {/* 棋盤環境框裝飾 overlay（pointer-events:none，不攔截 pan/zoom） */}
+            <BoardFrameOverlay />
           </div>
 
           {/* Mobile floating action bar (< md) — safe-area aware */}

--- a/src/components/Board/BoardFrameOverlay.tsx
+++ b/src/components/Board/BoardFrameOverlay.tsx
@@ -1,0 +1,102 @@
+/**
+ * BoardFrameOverlay — R24-C 棋盤環境框裝飾
+ *
+ * position: absolute; inset: 0; pointer-events: none; z-index: 10
+ * 不攔截任何 pan/zoom/click 事件，純視覺疊加。
+ *
+ * 包含：
+ * - CSS border 羊皮紙框 + inset shadow 磨損暗角
+ * - 四角銅角扣 SVG（L 型 + 3 鉚釘，scale 複用同一 path）
+ *
+ * ⚠️ SVG presentation attr（fill/stroke）不接受 CSS var()，全用字面 hex 色值。
+ */
+
+import React from 'react';
+
+const CORNER_SIZE = 40;
+
+interface CornerBracketProps {
+  style: React.CSSProperties;
+  /** SVG <g> 的 transform（旋轉/翻轉） */
+  svgTransform: string;
+}
+
+// 單個銅角扣 SVG。四角透過不同 svgTransform 複用。
+const CornerBracket: React.FC<CornerBracketProps> = ({ style, svgTransform }) => (
+  <svg
+    width={CORNER_SIZE}
+    height={CORNER_SIZE}
+    viewBox="0 0 40 40"
+    style={{
+      position: 'absolute',
+      pointerEvents: 'none',
+      overflow: 'visible',
+      ...style,
+    }}
+    aria-hidden="true"
+  >
+    <defs>
+      <linearGradient id="copper-grad" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0%" stopColor="#D4A030" />
+        <stop offset="100%" stopColor="#8B6914" />
+      </linearGradient>
+    </defs>
+    <g transform={svgTransform}>
+      {/* 角架 L 型 */}
+      <path
+        d="M2,2 L2,36 L10,36 L10,12 L36,12 L36,2 Z"
+        fill="url(#copper-grad)"
+        stroke="#7A5C10"
+        strokeWidth="0.8"
+      />
+      {/* 鉚釘 1（主角落） */}
+      <circle cx="6" cy="6" r="2.5" fill="#D4A030" stroke="#8B6914" strokeWidth="0.6" />
+      {/* 鉚釘 2（下臂） */}
+      <circle cx="6" cy="28" r="1.8" fill="#C49028" stroke="#7A5C10" strokeWidth="0.5" />
+      {/* 鉚釘 3（右臂） */}
+      <circle cx="28" cy="6" r="1.8" fill="#C49028" stroke="#7A5C10" strokeWidth="0.5" />
+    </g>
+  </svg>
+);
+
+function BoardFrameOverlayInner() {
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: 'absolute',
+        inset: 0,
+        pointerEvents: 'none',
+        zIndex: 10,
+        // 羊皮紙仿舊邊框（視覺，不佔 layout 空間）
+        border: '10px solid oklch(0.65 0.05 70 / 0.85)',
+        // 磨損暗角 inset shadow
+        boxShadow:
+          'inset 0 0 20px oklch(0.42 0.03 70 / 0.35), inset 0 0 8px oklch(0.35 0.04 65 / 0.25)',
+      }}
+    >
+      {/* 左上角 — 無旋轉 */}
+      <CornerBracket
+        svgTransform="translate(0,0)"
+        style={{ top: -10, left: -10 }}
+      />
+      {/* 右上角 — 水平鏡像（scaleX -1，translate 補回） */}
+      <CornerBracket
+        svgTransform="translate(40,0) scale(-1,1)"
+        style={{ top: -10, right: -10 }}
+      />
+      {/* 左下角 — 垂直鏡像 */}
+      <CornerBracket
+        svgTransform="translate(0,40) scale(1,-1)"
+        style={{ bottom: -10, left: -10 }}
+      />
+      {/* 右下角 — 180° (scaleX -1, scaleY -1) */}
+      <CornerBracket
+        svgTransform="translate(40,40) scale(-1,-1)"
+        style={{ bottom: -10, right: -10 }}
+      />
+    </div>
+  );
+}
+
+export const BoardFrameOverlay = React.memo(BoardFrameOverlayInner);

--- a/src/components/Board/HexGrid.tsx
+++ b/src/components/Board/HexGrid.tsx
@@ -370,7 +370,7 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
         lastPaintedCoord.current = null;
         onTouchEnd(e);
       }}
-      style={{ cursor: editable && editMode === 'paint' ? 'crosshair' : 'grab', touchAction: 'none', background: 'var(--color-warm-cream-200)' }}
+      style={{ cursor: editable && editMode === 'paint' ? 'crosshair' : 'grab', touchAction: 'none', background: 'var(--board-inner-bg)' }}
     >
       {/* Zoom reset button */}
       <button
@@ -416,6 +416,17 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
           {/* R24-B 棋子 defs：9 種地點 symbol + 共用 drop-shadow filter
               LocationMarker 以 <use href="#piece-{location}"> 引用 */}
           <PieceDefs />
+          {/* R24-C 羅盤底紋：opacity 0.04，純氛圍，不搶地形視覺 */}
+          <use
+            href="#compass-rose"
+            x={viewBoxWidth / 2 - 80}
+            y={viewBoxHeight / 2 - 80}
+            width={160}
+            height={160}
+            color="oklch(0.50 0.04 70)"
+            opacity={0.04}
+            style={{ pointerEvents: 'none' }}
+          />
           {/* grain-overlay 套在容器層（O(1) 效能方案）：整 SVG 畫布計算一次 feTurbulence，402 格共用 */}
           <g filter="url(#grain-overlay)">
           <g transform={`translate(${gridOffset}, ${gridOffset})`}>

--- a/src/components/Board/TerrainDefs.tsx
+++ b/src/components/Board/TerrainDefs.tsx
@@ -799,5 +799,21 @@ export const TerrainDefs: React.FC = () => (
       <circle cx="47" cy="54" r="1.4" fill="#484848" opacity="0.45" />
     </symbol>
 
+    {/* ── R24-C 羅盤底紋 symbol（opacity 0.04 極淡，純氛圍）
+        在 HexGrid SVG 以 <use href="#compass-rose"> 引用，currentColor + color 屬性控色
+        ⚠️ 只 append，不改現有任何 defs ── */}
+    <symbol id="compass-rose" viewBox="-50 -50 100 100">
+      {/* 8 方向細線 */}
+      <line x1="0" y1="-45" x2="0" y2="45" stroke="currentColor" strokeWidth="0.8" />
+      <line x1="-45" y1="0" x2="45" y2="0" stroke="currentColor" strokeWidth="0.8" />
+      <line x1="-32" y1="-32" x2="32" y2="32" stroke="currentColor" strokeWidth="0.5" />
+      <line x1="32" y1="-32" x2="-32" y2="32" stroke="currentColor" strokeWidth="0.5" />
+      {/* 外圈 */}
+      <circle cx="0" cy="0" r="42" fill="none" stroke="currentColor" strokeWidth="0.6" />
+      <circle cx="0" cy="0" r="30" fill="none" stroke="currentColor" strokeWidth="0.4" />
+      {/* 北方三角尖 */}
+      <polygon points="0,-44 -4,-32 4,-32" fill="currentColor" />
+    </symbol>
+
   </defs>
 );

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -161,4 +161,68 @@
   --toast-bg: var(--color-stone-900);
   --toast-text: var(--color-warm-cream-50);
   --toast-border: oklch(0.82 0.03 80 / 0.3);
+
+  /* ── R24-C 棋盤環境框 token ──────────────────────────────────────────── */
+  /* 木紋桌面背景 (light) */
+  --board-bg-light:
+    repeating-linear-gradient(
+      92deg,
+      transparent 0px,
+      oklch(0.72 0.04 62 / 0.06) 1px,
+      transparent 2px,
+      transparent 18px
+    ),
+    repeating-linear-gradient(
+      89deg,
+      transparent 0px,
+      oklch(0.68 0.05 60 / 0.04) 1px,
+      transparent 3px,
+      transparent 32px
+    ),
+    linear-gradient(
+      175deg,
+      oklch(0.75 0.05 65),
+      oklch(0.70 0.055 62),
+      oklch(0.72 0.05 64),
+      oklch(0.68 0.06 60)
+    );
+  /* 木紋桌面背景 (dark) */
+  --board-bg-dark:
+    repeating-linear-gradient(
+      92deg,
+      transparent 0px,
+      oklch(0.95 0.01 80 / 0.04) 1px,
+      transparent 2px,
+      transparent 18px
+    ),
+    repeating-linear-gradient(
+      89deg,
+      transparent 0px,
+      oklch(0.90 0.01 75 / 0.03) 1px,
+      transparent 3px,
+      transparent 32px
+    ),
+    linear-gradient(
+      175deg,
+      oklch(0.22 0.03 60),
+      oklch(0.19 0.025 58),
+      oklch(0.21 0.03 62),
+      oklch(0.18 0.025 56)
+    );
+  /* 棋盤 HexGrid 內部背景（比原本 warm-cream-200 更暖，仿羊皮紙） */
+  --board-inner-bg: oklch(0.89 0.025 80);
+  /* 落地陰影（強化版） */
+  --board-frame-shadow:
+    0 8px 32px oklch(0.15 0.04 60 / 0.55),
+    0 3px 12px oklch(0.15 0.04 60 / 0.40),
+    0 1px 4px  oklch(0.10 0.03 60 / 0.30);
+  /* 銅角扣顏色 token */
+  --copper-fill-light: oklch(0.65 0.08 72);
+  --copper-stroke-light: oklch(0.50 0.08 68);
+  --copper-highlight-light: oklch(0.72 0.09 78);
+}
+
+/* ── R24-C dark mode 覆蓋 ────────────────────────────────────────────── */
+[data-theme="dark"] {
+  --board-bg-light: var(--board-bg-dark);
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -168,23 +168,23 @@
     repeating-linear-gradient(
       92deg,
       transparent 0px,
-      oklch(0.72 0.04 62 / 0.06) 1px,
+      oklch(0.58 0.06 56 / 0.14) 1px,
       transparent 2px,
-      transparent 18px
+      transparent 16px
     ),
     repeating-linear-gradient(
       89deg,
       transparent 0px,
-      oklch(0.68 0.05 60 / 0.04) 1px,
+      oklch(0.34 0.05 48 / 0.16) 1px,
       transparent 3px,
-      transparent 32px
+      transparent 30px
     ),
     linear-gradient(
       175deg,
-      oklch(0.75 0.05 65),
-      oklch(0.70 0.055 62),
-      oklch(0.72 0.05 64),
-      oklch(0.68 0.06 60)
+      oklch(0.50 0.072 56),
+      oklch(0.43 0.078 51),
+      oklch(0.47 0.075 54),
+      oklch(0.41 0.082 49)
     );
   /* 木紋桌面背景 (dark) */
   --board-bg-dark:
@@ -209,8 +209,8 @@
       oklch(0.21 0.03 62),
       oklch(0.18 0.025 56)
     );
-  /* 棋盤 HexGrid 內部背景（比原本 warm-cream-200 更暖，仿羊皮紙） */
-  --board-inner-bg: oklch(0.89 0.025 80);
+  /* 棋盤 HexGrid 內部背景：透明，露出容器層的木桌（否則淺底鋪滿會蓋掉木桌） */
+  --board-inner-bg: transparent;
   /* 落地陰影（強化版） */
   --board-frame-shadow:
     0 8px 32px oklch(0.15 0.04 60 / 0.55),


### PR DESCRIPTION
## R24-C 棋盤環境框（R24 棋盤美術三階段最後一塊）

讓六角棋盤從「浮在米色虛空」變成「攤在木桌上的地圖」。

### 內容
- **深胡桃木桌面**：CSS 木紋 gradient（oklch 0.41–0.50 深褐），棋盤跳出坐在桌上
- **羊皮紙外框 + 四角銅角扣**：App.tsx 容器層 overlay（`pointer-events:none`，不碰 pan/zoom）
- **落地陰影**：棋盤對木桌的 drop-shadow
- **羅盤底紋**：棋盤中心極淡 compass（opacity 0.04）
- 卷軸標題省略（不擠壓 402 格可視區）

### CEO 親驗（vite + Playwright，desktop 1440 + mobile 375）
- ✅ 視覺：深胡桃木桌 + 棋盤跳出 + 四角銅扣 + 陰影，不再浮米色
- ✅ 框 overlay `pointer-events:none`，中心 elementFromPoint 命中 polygon 棋盤格（不攔截點擊）
- ✅ 修正關鍵 bug：HexGrid 淺底鋪滿原本蓋掉木桌 → 改 inner-bg 透明露出木桌
- ✅ build 綠 / vitest 411 全過 / eye 0 breaking
- 安全雙審：純視覺層，不觸發

🤖 Generated with [Claude Code](https://claude.com/claude-code)