### PR TITLE
feat(R25): 遊戲內右側欄主題統一 — 目標卡/目前 badge 去天藍改羊皮紙酒紅

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1224,8 +1224,8 @@ function App() {
                             <span
                               className="text-xs px-1.5 py-0.5 rounded-full font-semibold"
                               style={{
-                                backgroundColor: 'var(--color-info)',
-                                color: 'var(--color-warm-cream-50)',
+                                backgroundColor: 'var(--color-accent-turn)',
+                                color: 'var(--color-accent-turn-fg)',
                               }}
                             >
                               {t('app.current')}

--- a/src/components/Game/ObjectiveCardBadge.tsx
+++ b/src/components/Game/ObjectiveCardBadge.tsx
@@ -19,8 +19,8 @@ export function ObjectiveCardBadge({ card, score, className = '' }: ObjectiveCar
       aria-label={`${title}. ${description}`}
       className={`rounded-lg px-3 py-2 text-left ${className}`}
       style={{
-        backgroundColor: 'oklch(0.97 0.02 255)',
-        border: '1px solid var(--color-player-blue)',
+        backgroundColor: 'var(--color-quest-bg)',
+        border: '1px solid var(--color-quest-border)',
         color: 'var(--color-stone-800)',
       }}
     >
@@ -33,8 +33,8 @@ export function ObjectiveCardBadge({ card, score, className = '' }: ObjectiveCar
             data-testid="objective-score-preview"
             className="shrink-0 rounded-full px-2 py-0.5 text-[11px] font-bold leading-none"
             style={{
-              backgroundColor: 'var(--color-player-blue)',
-              color: 'var(--color-warm-cream-50)',
+              backgroundColor: 'var(--color-quest-score-bg)',
+              color: 'var(--color-quest-score-fg)',
             }}
           >
             {t('objectiveCard.currentScore', { score })}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -76,6 +76,14 @@
   --color-danger: var(--color-wine-600);
   --color-info: var(--color-player-blue);
 
+  /* R25: Quest card & turn indicator tokens */
+  --color-quest-bg:       var(--color-amber-50);
+  --color-quest-border:   var(--color-amber-600);
+  --color-quest-score-bg: var(--color-wine-600);
+  --color-quest-score-fg: var(--color-warm-cream-50);
+  --color-accent-turn:    var(--color-amber-600);
+  --color-accent-turn-fg: var(--color-warm-cream-50);
+
   /* Typography */
   --font-display: 'Cormorant Garamond', 'Times New Roman', serif;
   --font-body: 'Manrope', 'Segoe UI', system-ui, sans-serif;


### PR DESCRIPTION
## R25 右側欄主題統一

CEO 實地玩發現右側欄「目標卡(農夫/領主/漁夫)+ 當前玩家『目前』badge」是亮天藍，破壞全遊戲酒紅/羊皮紙/木頭主題，且藍是玩家色(語意混淆)。R19/R23 主題 sweep 漏網、整局常駐可見的破口。

### 內容
- 目標卡：天藍底/框/分數 badge → **羊皮紙 amber-50 底 + amber-600 琥珀框 + wine-600 酒紅分數 badge**
- 「目前」badge：`--color-info`(player-blue) → **amber-600 琥珀**(去玩家色)
- 新增 6 個 quest/accent token，**`--color-info` 本身不動**(blast radius 僅 App.tsx:1227 一處,零誤傷)
- **玩家色語意全保留**(即時計分圓點/玩家列表/進度條)

### CEO 親驗(vite preview + Playwright,1440)
- ✅ computed style:卡底 oklch(0.97 0.02 80)amber-50 / 框 amber-600 / badge wine-600 / 目前 amber-600
- ✅ 側欄藍色掃描 0 命中(天藍清零)
- ✅ Player1 紅點 / Player2 青點玩家色保留,不再與目標卡框混淆
- ✅ build 綠 / vitest 411 全過 / eye 0 breaking
- 安全雙審:純視覺 token swap,不觸發

🤖 Generated with [Claude Code](https://claude.com/claude-code)