### PR TITLE
feat(R26): 主選單英雄級改造 — 王國紋章 + 氛圍背景，告別米色虛空

### DIFF
--- a/src/components/Menu/KingdomCrest.tsx
+++ b/src/components/Menu/KingdomCrest.tsx
@@ -64,19 +64,19 @@ export function KingdomCrest({ size = 'lg', isDark = false, style }: KingdomCres
         fill={shieldBg}
       />
 
-      {/* ── 皇冠（盾上半段中央） ── */}
-      {/* 底座 */}
-      <rect x="40" y="26" width="40" height="8" rx="2" fill={gold} />
-      {/* 左齒 */}
-      <rect x="40" y="16" width="8"  height="12" rx="1" fill={gold} />
-      {/* 中齒（最高） */}
-      <rect x="56" y="12" width="8"  height="16" rx="1" fill={gold} />
-      {/* 右齒 */}
-      <rect x="72" y="16" width="8"  height="12" rx="1" fill={gold} />
-      {/* 三顆珠 */}
-      <circle cx="44" cy="14" r="3" fill={gold} />
-      <circle cx="60" cy="10" r="3" fill={gold} />
-      <circle cx="76" cy="14" r="3" fill={gold} />
+      {/* ── 皇冠（盾上半段中央，尖頂冠 + 寶石 + 明珠） ── */}
+      {/* 冠身：3 尖頂 + 谷（非矩形塊，讀作皇冠） */}
+      <path d="M39 32 L46 18 L53 27 L60 14 L67 27 L74 18 L81 32 Z" fill={gold} />
+      {/* 冠帶 */}
+      <rect x="37" y="31" width="46" height="8" rx="2" fill={gold} />
+      {/* 冠帶寶石（酒紅） */}
+      <circle cx="60" cy="35" r="2.4" fill={wine} />
+      <circle cx="48" cy="35" r="1.5" fill={wine} opacity="0.8" />
+      <circle cx="72" cy="35" r="1.5" fill={wine} opacity="0.8" />
+      {/* 尖頂明珠（金，酒紅細描邊增辨識） */}
+      <circle cx="46" cy="16" r="2.8" fill={gold} stroke={wine} strokeWidth="0.5" />
+      <circle cx="60" cy="12" r="3.2" fill={gold} stroke={wine} strokeWidth="0.5" />
+      <circle cx="74" cy="16" r="2.8" fill={gold} stroke={wine} strokeWidth="0.5" />
 
       {/* ── 盾外框雙線 ── */}
       {/* 外描邊（酒紅，粗） */}

--- a/src/components/Menu/KingdomCrest.tsx
+++ b/src/components/Menu/KingdomCrest.tsx
@@ -1,0 +1,121 @@
+interface KingdomCrestProps {
+  /** lg = desktop 120×140 | sm = mobile 84×98 */
+  size?: 'lg' | 'sm';
+  isDark?: boolean;
+  style?: React.CSSProperties;
+}
+
+export function KingdomCrest({ size = 'lg', isDark = false, style }: KingdomCrestProps) {
+  // 配色：字面 hex，不用 CSS var（SVG presentation attr 吃不到 var）
+  const wine     = isDark ? '#c87080' : '#7b2d3a';
+  const gold     = isDark ? '#f0cc7a' : '#c9a84c';
+  const shieldBg = isDark ? '#2a1f16' : '#f5efe0';
+  const castleFill = wine;
+  const castleOpacity = isDark ? 0.90 : 0.85;
+  const bannerFill = isDark ? '#5a1e28' : '#7b2d3a';
+
+  // 內框路徑（盾型略縮 4px，作金色細線）
+  const innerShield = 'M14 14 L106 14 L106 88 Q106 124 60 134 Q14 124 14 88 Z';
+
+  const width  = size === 'lg' ? 120 : 84;
+  const height = size === 'lg' ? 140 : 98;
+
+  return (
+    <svg
+      viewBox="0 0 120 140"
+      width={width}
+      height={height}
+      style={{ display: 'block', pointerEvents: 'none', ...style }}
+      aria-hidden="true"
+      role="img"
+    >
+      {/* ── 盾底填充 ── */}
+      <path
+        d="M10 10 L110 10 L110 88 Q110 128 60 138 Q10 128 10 88 Z"
+        fill={shieldBg}
+        stroke="none"
+      />
+
+      {/* ── 盾上 1/3 分線 ── */}
+      <line x1="12" y1="48" x2="108" y2="48" stroke={gold} strokeWidth="0.8" opacity="0.7" />
+
+      {/* ── 城堡剪影（盾下半段） ── */}
+      {/* 左塔 */}
+      <rect x="22" y="62" width="18" height="30" fill={castleFill} fillOpacity={castleOpacity} />
+      {/* 左塔齒堞 3 個 */}
+      <rect x="22" y="57" width="5"  height="7" fill={castleFill} fillOpacity={castleOpacity} />
+      <rect x="29" y="57" width="5"  height="7" fill={castleFill} fillOpacity={castleOpacity} />
+      <rect x="36" y="57" width="5"  height="7" fill={castleFill} fillOpacity={castleOpacity} />
+      {/* 右塔 */}
+      <rect x="80" y="62" width="18" height="30" fill={castleFill} fillOpacity={castleOpacity} />
+      {/* 右塔齒堞 3 個 */}
+      <rect x="80" y="57" width="5"  height="7" fill={castleFill} fillOpacity={castleOpacity} />
+      <rect x="87" y="57" width="5"  height="7" fill={castleFill} fillOpacity={castleOpacity} />
+      <rect x="94" y="57" width="5"  height="7" fill={castleFill} fillOpacity={castleOpacity} />
+      {/* 中體 */}
+      <rect x="36" y="70" width="48" height="22" fill={castleFill} fillOpacity={castleOpacity} />
+      {/* 中體齒堞 3 個 */}
+      <rect x="41" y="65" width="5"  height="7" fill={castleFill} fillOpacity={castleOpacity} />
+      <rect x="55" y="65" width="5"  height="7" fill={castleFill} fillOpacity={castleOpacity} />
+      <rect x="69" y="65" width="5"  height="7" fill={castleFill} fillOpacity={castleOpacity} />
+      {/* 城門拱（鏤空效果：用 shieldBg 填充蓋回） */}
+      <path
+        d="M51 92 L51 78 Q60 72 69 78 L69 92 Z"
+        fill={shieldBg}
+      />
+
+      {/* ── 皇冠（盾上半段中央） ── */}
+      {/* 底座 */}
+      <rect x="40" y="26" width="40" height="8" rx="2" fill={gold} />
+      {/* 左齒 */}
+      <rect x="40" y="16" width="8"  height="12" rx="1" fill={gold} />
+      {/* 中齒（最高） */}
+      <rect x="56" y="12" width="8"  height="16" rx="1" fill={gold} />
+      {/* 右齒 */}
+      <rect x="72" y="16" width="8"  height="12" rx="1" fill={gold} />
+      {/* 三顆珠 */}
+      <circle cx="44" cy="14" r="3" fill={gold} />
+      <circle cx="60" cy="10" r="3" fill={gold} />
+      <circle cx="76" cy="14" r="3" fill={gold} />
+
+      {/* ── 盾外框雙線 ── */}
+      {/* 外描邊（酒紅，粗） */}
+      <path
+        d="M10 10 L110 10 L110 88 Q110 128 60 138 Q10 128 10 88 Z"
+        fill="none"
+        stroke={wine}
+        strokeWidth="3.5"
+      />
+      {/* 內描邊（金色，細） */}
+      <path
+        d={innerShield}
+        fill="none"
+        stroke={gold}
+        strokeWidth="1"
+      />
+
+      {/* ── 四角月桂卷紋（純 stroke） ── */}
+      {/* 左上 */}
+      <path d="M12 12 Q4 8 4 16 Q4 24 12 22" fill="none" stroke={gold} strokeWidth="1.5" strokeLinecap="round" />
+      {/* 右上 */}
+      <path d="M108 12 Q116 8 116 16 Q116 24 108 22" fill="none" stroke={gold} strokeWidth="1.5" strokeLinecap="round" />
+      {/* 左下（靠盾底弧） */}
+      <path d="M22 112 Q12 118 16 128 Q20 136 28 132" fill="none" stroke={gold} strokeWidth="1.5" strokeLinecap="round" />
+      {/* 右下 */}
+      <path d="M98 112 Q108 118 104 128 Q100 136 92 132" fill="none" stroke={gold} strokeWidth="1.5" strokeLinecap="round" />
+
+      {/* ── 底部綬帶 ── */}
+      <path
+        d="M22 126 Q60 138 98 126 L98 132 Q60 146 22 132 Z"
+        fill={bannerFill}
+        stroke={gold}
+        strokeWidth="1"
+      />
+
+      {/* 綬帶中央裝飾點 */}
+      <circle cx="60" cy="130" r="2" fill={gold} opacity="0.8" />
+      <circle cx="48" cy="130" r="1.2" fill={gold} opacity="0.5" />
+      <circle cx="72" cy="130" r="1.2" fill={gold} opacity="0.5" />
+    </svg>
+  );
+}

--- a/src/components/Menu/MainMenu.tsx
+++ b/src/components/Menu/MainMenu.tsx
@@ -4,6 +4,8 @@ import { loadGame, clearSave } from '../../store/persistence';
 import { gameStore } from '../../store/gameStore';
 import { useAchievementStore, getUnlockedCount } from '../../store/achievementStore';
 import { useTutorialStore } from '../../store/tutorialStore';
+import { KingdomCrest } from './KingdomCrest';
+import { MenuBackground } from './MenuBackground';
 import {
   AchievementIcon,
   MutedIcon,
@@ -50,6 +52,7 @@ export function MainMenu({
   const [achievementOpen, setAchievementOpen] = useState(false);
   const achievementUnlockedCount = useAchievementStore((s) => getUnlockedCount(s.achievements));
   const startTutorial = useTutorialStore((s) => s.startTutorial);
+  const isDark = typeof document !== 'undefined' && document.documentElement.dataset.theme === 'dark';
 
   const handleContinue = () => {
     gameStore.getState().loadSavedGame();
@@ -71,6 +74,9 @@ export function MainMenu({
       className="min-h-screen flex flex-col items-center justify-center relative overflow-hidden"
       style={{ background: 'var(--texture-parchment)', backgroundColor: 'var(--color-warm-cream-100)' }}
     >
+      {/* R26：氛圍背景層（絕對定位，pointer-events none） */}
+      <MenuBackground isDark={isDark} />
+
       {/* Control bar — top right */}
       <div className="absolute top-4 right-4 flex items-center gap-2 z-10">
         <select
@@ -115,20 +121,59 @@ export function MainMenu({
         </button>
       </div>
 
-      {/* Centre content */}
-      <div className="flex flex-col items-center w-full max-w-sm px-6 gap-6">
+      {/* Centre content（z-index 高於背景層） */}
+      <div className="flex flex-col items-center w-full max-w-sm px-6 gap-6" style={{ position: 'relative', zIndex: 3 }}>
 
         {/* Logo + subtitle */}
         <div className="text-center mb-2">
+
+          {/* R26：王國紋章（標題上方） */}
+          <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '0.5rem' }}>
+            <KingdomCrest
+              isDark={isDark}
+              style={{ width: 'clamp(84px, 10vw, 120px)', height: 'auto' }}
+            />
+          </div>
+
+          {/* R26：標題升級——漸層 + 自適應字級 */}
           <h1
-            className="font-display text-display-xl leading-tight"
-            style={{ color: 'var(--color-wine-700)' }}
+            className="font-display menu-title-gradient leading-tight"
+            style={{
+              fontSize: 'clamp(2.5rem, 5vw, 3.5rem)',
+            }}
           >
             {t('common.appName')}
           </h1>
+
+          {/* R26：Flourish 分隔線 SVG */}
+          <svg
+            width="200"
+            height="12"
+            viewBox="0 0 200 12"
+            style={{ display: 'block', margin: '4px auto 0', pointerEvents: 'none' }}
+            aria-hidden="true"
+          >
+            {/* 左線 */}
+            <line x1="10" y1="6" x2="78" y2="6" className="menu-flourish-line" strokeWidth="1" />
+            {/* 左菱形 */}
+            <rect x="84" y="3.5" width="5" height="5" transform="rotate(45 86.5 6)" className="menu-flourish-diamond" />
+            {/* 中央小皇冠形符號：三個小點 */}
+            <circle cx="97"  cy="6" r="1.5" className="menu-flourish-diamond" />
+            <circle cx="100" cy="4" r="1.5" className="menu-flourish-diamond" />
+            <circle cx="103" cy="6" r="1.5" className="menu-flourish-diamond" />
+            {/* 右菱形 */}
+            <rect x="111" y="3.5" width="5" height="5" transform="rotate(45 113.5 6)" className="menu-flourish-diamond" />
+            {/* 右線 */}
+            <line x1="122" y1="6" x2="190" y2="6" className="menu-flourish-line" strokeWidth="1" />
+          </svg>
+
           <p
-            className="mt-1 text-body-sm font-body tracking-wide"
-            style={{ color: 'var(--color-stone-600)' }}
+            className="mt-2 text-body-sm font-body"
+            style={{
+              color: 'var(--color-stone-600)',
+              opacity: 0.85,
+              letterSpacing: '0.12em',
+            }}
           >
             {t('menu.subtitle')}
           </p>

--- a/src/components/Menu/MenuBackground.tsx
+++ b/src/components/Menu/MenuBackground.tsx
@@ -1,0 +1,171 @@
+/**
+ * MenuBackground — R26 主選單氛圍背景
+ * 三層絕對定位，全部 pointer-events: none
+ *
+ * 層 0 (z=0): 羅盤底紋（desktop only）
+ * 層 1 (z=1): Vignette 暈影（CSS token）
+ * 層 2 (z=2): 城堡天際線剪影（底部）
+ */
+
+interface MenuBackgroundProps {
+  isDark?: boolean;
+}
+
+export function MenuBackground({ isDark = false }: MenuBackgroundProps) {
+  const skylineFill = isDark ? '#e8a0a8' : '#7b2d3a';
+  const compassStroke = '#7b2d3a';
+
+  return (
+    <>
+      {/* ── 層 0：羅盤底紋（desktop only） ── */}
+      <div
+        className="hidden sm:block"
+        style={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          width: 480,
+          height: 480,
+          opacity: isDark ? 0.025 : 0.03,
+          pointerEvents: 'none',
+          zIndex: 0,
+        }}
+      >
+        <svg viewBox="0 0 480 480" width="480" height="480" aria-hidden="true">
+          {/* 外圓環 */}
+          <circle cx="240" cy="240" r="230" fill="none" stroke={compassStroke} strokeWidth="1.5" />
+          <circle cx="240" cy="240" r="210" fill="none" stroke={compassStroke} strokeWidth="0.8" />
+          {/* 16 方位射線 */}
+          {Array.from({ length: 16 }).map((_, i) => {
+            const angle = (i * Math.PI * 2) / 16;
+            const len = i % 4 === 0 ? 200 : i % 2 === 0 ? 180 : 160;
+            return (
+              <line
+                key={i}
+                x1={240 + Math.cos(angle) * 30}
+                y1={240 + Math.sin(angle) * 30}
+                x2={240 + Math.cos(angle) * len}
+                y2={240 + Math.sin(angle) * len}
+                stroke={compassStroke}
+                strokeWidth={i % 4 === 0 ? 1.2 : 0.7}
+              />
+            );
+          })}
+          {/* 內圓 */}
+          <circle cx="240" cy="240" r="40" fill="none" stroke="#c9a84c" strokeWidth="1" />
+          <circle cx="240" cy="240" r="8"  fill="#c9a84c" opacity="0.5" />
+        </svg>
+      </div>
+
+      {/* ── 層 1：Vignette 暈影 ── */}
+      {/* dark mode 由 tokens.css [data-theme=dark] 覆蓋 --menu-vignette-light */}
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          zIndex: 1,
+          pointerEvents: 'none',
+          background: 'var(--menu-vignette-light)',
+        }}
+      />
+
+      {/* ── 層 2：城堡天際線剪影（底部） ── */}
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          zIndex: 2,
+          pointerEvents: 'none',
+          overflow: 'hidden',
+        }}
+      >
+        <svg
+          viewBox="0 0 1440 160"
+          preserveAspectRatio="xMidYMax slice"
+          width="100%"
+          style={{
+            display: 'block',
+            opacity: 'var(--menu-skyline-opacity-light)',
+          }}
+          aria-hidden="true"
+        >
+          {/* 遠山左 */}
+          <path
+            d="M0 145 Q150 120 300 130 Q400 122 500 132 L500 160 L0 160 Z"
+            fill={skylineFill}
+          />
+          {/* 遠山右 */}
+          <path
+            d="M940 130 Q1100 118 1300 128 Q1380 122 1440 126 L1440 160 L940 160 Z"
+            fill={skylineFill}
+          />
+          {/* 地基丘陵 */}
+          <path
+            d="M0 160 Q200 135 400 148 Q600 133 800 142 Q1000 132 1200 143 Q1320 137 1440 134 L1440 160 Z"
+            fill={skylineFill}
+          />
+          {/* 前景丘陵（稍亮疊加感） */}
+          <path
+            d="M0 150 Q360 138 720 145 Q1080 138 1440 143 L1440 160 L0 160 Z"
+            fill={skylineFill}
+            fillOpacity="0.15"
+          />
+
+          {/* ── 左側小塔 ── */}
+          <rect x="140" y="105" width="28" height="45" fill={skylineFill} />
+          {/* 左塔齒堞 */}
+          <rect x="140" y="100" width="6" height="7" fill={skylineFill} />
+          <rect x="149" y="100" width="6" height="7" fill={skylineFill} />
+          <rect x="158" y="100" width="6" height="7" fill={skylineFill} />
+          {/* 左塔門 */}
+          <rect x="151" y="130" width="6" height="20" fill={skylineFill} fillOpacity="0.4" />
+
+          {/* ── 右側小塔 ── */}
+          <rect x="1272" y="105" width="28" height="45" fill={skylineFill} />
+          {/* 右塔齒堞 */}
+          <rect x="1272" y="100" width="6" height="7" fill={skylineFill} />
+          <rect x="1281" y="100" width="6" height="7" fill={skylineFill} />
+          <rect x="1290" y="100" width="6" height="7" fill={skylineFill} />
+          {/* 右塔門 */}
+          <rect x="1283" y="130" width="6" height="20" fill={skylineFill} fillOpacity="0.4" />
+
+          {/* ── 中央主城 ── */}
+          {/* 左側塔 */}
+          <rect x="606" y="80" width="38" height="60" fill={skylineFill} />
+          {/* 左塔齒堞 */}
+          <rect x="606" y="74" width="7" height="8" fill={skylineFill} />
+          <rect x="616" y="74" width="7" height="8" fill={skylineFill} />
+          <rect x="626" y="74" width="7" height="8" fill={skylineFill} />
+          <rect x="636" y="74" width="7" height="8" fill={skylineFill} />
+
+          {/* 右側塔 */}
+          <rect x="796" y="80" width="38" height="60" fill={skylineFill} />
+          {/* 右塔齒堞 */}
+          <rect x="796" y="74" width="7" height="8" fill={skylineFill} />
+          <rect x="806" y="74" width="7" height="8" fill={skylineFill} />
+          <rect x="816" y="74" width="7" height="8" fill={skylineFill} />
+          <rect x="826" y="74" width="7" height="8" fill={skylineFill} />
+
+          {/* 中體 */}
+          <rect x="632" y="90" width="176" height="50" fill={skylineFill} />
+
+          {/* 中央主塔（最高） */}
+          <rect x="692" y="55" width="56" height="85" fill={skylineFill} />
+          {/* 主塔齒堞 */}
+          <rect x="692" y="48" width="9"  height="9" fill={skylineFill} />
+          <rect x="704" y="48" width="9"  height="9" fill={skylineFill} />
+          <rect x="716" y="48" width="9"  height="9" fill={skylineFill} />
+          <rect x="728" y="48" width="9"  height="9" fill={skylineFill} />
+          <rect x="740" y="48" width="9"  height="9" fill={skylineFill} />
+
+          {/* 城門拱洞（鏤空，用低 opacity 矩形+弧表示） */}
+          <rect  x="712" y="115" width="16" height="25" fill={skylineFill} fillOpacity="0.25" />
+          <ellipse cx="720" cy="115" rx="8" ry="5" fill={skylineFill} fillOpacity="0.25" />
+        </svg>
+      </div>
+    </>
+  );
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -170,6 +170,26 @@
   --toast-text: var(--color-warm-cream-50);
   --toast-border: oklch(0.82 0.03 80 / 0.3);
 
+  /* ── R26 主選單英雄視覺 token ─────────────────────────────────────────── */
+  --menu-vignette-light: radial-gradient(
+    ellipse 80% 70% at 50% 40%,
+    transparent 0%,
+    transparent 45%,
+    oklch(0.39 0.075 24 / 0.12) 75%,
+    oklch(0.25 0.055 20 / 0.22) 100%
+  );
+  --menu-vignette-dark: radial-gradient(
+    ellipse 80% 70% at 50% 40%,
+    transparent 0%,
+    transparent 35%,
+    oklch(0.15 0.04 24 / 0.45) 75%,
+    oklch(0.08 0.02 20 / 0.60) 100%
+  );
+  --menu-title-size-mobile: 3rem;
+  --menu-title-size-desktop: 3.5rem;
+  --menu-skyline-opacity-light: 0.07;
+  --menu-skyline-opacity-dark: 0.05;
+
   /* ── R24-C 棋盤環境框 token ──────────────────────────────────────────── */
   /* 木紋桌面背景 (light) */
   --board-bg-light:
@@ -233,4 +253,36 @@
 /* ── R24-C dark mode 覆蓋 ────────────────────────────────────────────── */
 [data-theme="dark"] {
   --board-bg-light: var(--board-bg-dark);
+
+  /* ── R26 dark mode 覆蓋 */
+  --menu-vignette-light: var(--menu-vignette-dark);
+  --menu-skyline-opacity-light: var(--menu-skyline-opacity-dark);
+}
+
+/* ── R26 標題漸層 CSS class ─────────────────────────────────────────── */
+.menu-title-gradient {
+  background: linear-gradient(180deg, #7b2d3a 0%, #a0192e 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+[data-theme="dark"] .menu-title-gradient {
+  background: linear-gradient(180deg, #e8a0a8 0%, #f0b8c0 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* ── R26 flourish SVG dark mode ─────────────────────────────────────── */
+.menu-flourish-line {
+  stroke: #c9a84c;
+}
+.menu-flourish-diamond {
+  fill: #c9a84c;
+}
+[data-theme="dark"] .menu-flourish-line {
+  stroke: #f0cc7a;
+}
+[data-theme="dark"] .menu-flourish-diamond {
+  fill: #f0cc7a;
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -172,11 +172,11 @@
 
   /* ── R26 主選單英雄視覺 token ─────────────────────────────────────────── */
   --menu-vignette-light: radial-gradient(
-    ellipse 80% 70% at 50% 40%,
+    ellipse 78% 68% at 50% 40%,
     transparent 0%,
     transparent 45%,
-    oklch(0.39 0.075 24 / 0.12) 75%,
-    oklch(0.25 0.055 20 / 0.22) 100%
+    oklch(0.39 0.075 24 / 0.18) 74%,
+    oklch(0.24 0.055 20 / 0.34) 100%
   );
   --menu-vignette-dark: radial-gradient(
     ellipse 80% 70% at 50% 40%,
@@ -187,8 +187,8 @@
   );
   --menu-title-size-mobile: 3rem;
   --menu-title-size-desktop: 3.5rem;
-  --menu-skyline-opacity-light: 0.07;
-  --menu-skyline-opacity-dark: 0.05;
+  --menu-skyline-opacity-light: 0.14;
+  --menu-skyline-opacity-dark: 0.10;
 
   /* ── R24-C 棋盤環境框 token ──────────────────────────────────────────── */
   /* 木紋桌面背景 (light) */


### PR DESCRIPTION
## R26 主選單英雄級視覺改造

CEO 實地玩對標 3A 找到 gap：主選單(第一印象畫面)是米色虛空 + 純文字標題,毫無遊戲識別。

### 內容
- **王國盾徽紋章**(新 KingdomCrest.tsx)：盾型酒紅外框+金內線、**尖頂皇冠+寶石明珠**、城堡剪影、月桂卷紋、綬帶
- **標題升級**：酒紅漸層 background-clip + 金色 flourish 裝飾
- **氛圍背景**(新 MenuBackground.tsx)：暈影裱框 + 城堡天際線剪影 + 羅盤底紋,全 pointer-events:none
- Light/Dark token + SVG 全字面 hex(無 var 坑)

### CEO 親驗(vite + Playwright,含紋章特寫)
- ✅ **CEO 親調**:CTO 初版皇冠用 rect 堆疊讀作金條→改尖頂冠+寶石明珠,清楚讀作皇冠(特寫驗證)
- ✅ **CEO 親調**:桌面天際線 opacity 0.07→0.14、暈影加強,中央羊皮紙裱框深度,不再純平米色
- ✅ Desktop 1440 + Mobile 375 皆有識別有氛圍,CTA 完整可點
- ✅ CTA elementFromPoint 命中 button(背景層 pointer-events:none 沒擋),點擊正常進 setup
- ✅ MainMenu onClick/handler 零改動,功能完整;build 綠/vitest 411/eye 0 breaking
- 安全雙審:純視覺,不觸發

🤖 Generated with [Claude Code](https://claude.com/claude-code)