### PR TITLE
feat(R28): GameOver 勝利畫面升級 — emoji 獎盃/獎牌 → 自家 SVG + 慶祝 juice

### DIFF
--- a/src/components/Game/GameOver.tsx
+++ b/src/components/Game/GameOver.tsx
@@ -4,6 +4,8 @@ import { ObjectiveCard } from '../../core/scoring';
 import { Player } from '../../types';
 import { useTranslation } from 'react-i18next';
 import { tObjective } from '../../i18n/formatters';
+import { TrophyIcon } from './TrophyIcon';
+import { MedalIcon } from './MedalIcon';
 
 const SCORE_SEGMENT_COLORS = [
   'var(--color-wine-600)',
@@ -35,6 +37,10 @@ export const GameOver = React.memo(function GameOver({
   onOpenReplay,
 }: GameOverProps) {
   const { t } = useTranslation();
+  // isDark：GameOver modal 不會在開著的情況下切 theme，讀一次即可
+  const isDark = typeof document !== 'undefined'
+    ? document.documentElement.classList.contains('dark')
+    : false;
   const sorted = [...finalScores].sort((a, b) => b.totalScore - a.totalScore);
   const getPlayer = (id: number) => players.find(p => p.id === id);
   const maxTotalScore = Math.max(...sorted.map(score => score.totalScore), 0);
@@ -112,8 +118,14 @@ export const GameOver = React.memo(function GameOver({
             {t('gameOver.heading')}
           </p>
           <div className="animate-banner-enter" style={{ marginTop: '0.5rem' }}>
-            <span style={{ fontSize: '2.5rem' }} aria-hidden="true">🏆</span>
+            <div
+              className="animate-trophy-glow"
+              style={{ display: 'inline-block', willChange: 'filter' }}
+            >
+              <TrophyIcon size={72} isDark={isDark} />
+            </div>
             <p
+              className="animate-champion-shimmer"
               style={{
                 fontFamily: 'var(--font-display)',
                 fontSize: 'var(--type-display-md)',
@@ -142,7 +154,7 @@ export const GameOver = React.memo(function GameOver({
         <div className="space-y-3 mb-6" role="list" aria-label={t('gameOver.finalRankings')}>
           {sorted.map((score, index) => {
             const player = getPlayer(score.playerId);
-            const medal = ['🥇', '🥈', '🥉'][index] ?? `${index + 1}.`;
+            const isMedalRank = index < 3;
             const playerName = player?.name ?? t('common.player', { number: score.playerId });
             const segments = [
               {
@@ -170,7 +182,10 @@ export const GameOver = React.memo(function GameOver({
                   animationDelay: `${index * 80}ms`,
                 }}
               >
-                <span className="text-2xl">{medal}</span>
+                {isMedalRank
+                  ? <MedalIcon rank={(index + 1) as 1 | 2 | 3} size={36} isDark={isDark} />
+                  : <span style={{ fontSize: '1.25rem', fontWeight: 700, color: 'var(--color-stone-500)', minWidth: 36, textAlign: 'center', display: 'inline-block' }}>{index + 1}.</span>
+                }
                 <div
                   className="w-5 h-5 rounded-full border border-gray-800 shrink-0"
                   style={{ backgroundColor: player?.color ?? '#ccc' }}

--- a/src/components/Game/MedalIcon.tsx
+++ b/src/components/Game/MedalIcon.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+
+interface MedalIconProps {
+  rank: 1 | 2 | 3;
+  size?: number;
+  isDark?: boolean;
+}
+
+export function MedalIcon({ rank, size = 36, isDark = false }: MedalIconProps) {
+  // 全字面 hex，不用 var()（SVG presentation attr 吃不到 CSS var）
+  // Light / Dark 配色
+  const config = {
+    1: {
+      medalFill:   isDark ? '#f0cc7a' : '#c9a84c',
+      rimColor:    isDark ? '#c4a030' : '#a07828',
+      innerRim:    isDark ? '#fff8dc' : '#ffe082',
+      ribbonEdge:  isDark ? '#c4a030' : '#a07828',
+      textColor:   isDark ? '#7b2d3a' : '#7b2d3a',
+    },
+    2: {
+      medalFill:   isDark ? '#cfd8dc' : '#b0bec5',
+      rimColor:    isDark ? '#90a4ae' : '#78909c',
+      innerRim:    isDark ? '#f5f5f5' : '#eceff1',
+      ribbonEdge:  isDark ? '#90a4ae' : '#78909c',
+      textColor:   isDark ? '#37474f' : '#455a64',
+    },
+    3: {
+      medalFill:   isDark ? '#c4834a' : '#a0672a',
+      rimColor:    isDark ? '#9e6030' : '#7a4d18',
+      innerRim:    isDark ? '#ffe0b2' : '#ffcc80',
+      ribbonEdge:  isDark ? '#9e6030' : '#7a4d18',
+      textColor:   isDark ? '#f5efe0' : '#f5efe0',
+    },
+  } as const;
+
+  const c = config[rank];
+
+  return (
+    <svg
+      viewBox="0 0 40 48"
+      width={size}
+      height={size}
+      style={{ display: 'block' }}
+      aria-hidden="true"
+      role="img"
+    >
+      {/* ① 綬帶頂（V 形） */}
+      <path
+        d="M12 12 L20 4 L28 12"
+        fill={c.medalFill}
+        stroke={c.ribbonEdge}
+        strokeWidth="1"
+      />
+
+      {/* ② 圓形主牌面 */}
+      <circle
+        cx="20"
+        cy="28"
+        r="16"
+        fill={c.medalFill}
+        stroke={c.rimColor}
+        strokeWidth="2"
+      />
+
+      {/* ③ 內圓細線（一圈裝飾） */}
+      <circle
+        cx="20"
+        cy="28"
+        r="12.5"
+        fill="none"
+        stroke={c.innerRim}
+        strokeWidth="0.8"
+        opacity="0.7"
+      />
+
+      {/* ④ 名次數字 */}
+      <text
+        x="20"
+        y="33"
+        textAnchor="middle"
+        fontSize="14"
+        fontWeight="bold"
+        fill={c.textColor}
+        fontFamily="system-ui, sans-serif"
+      >
+        {rank}
+      </text>
+
+      {/* ⑤ 微光點（牌面左上，增質感） */}
+      <circle cx="13" cy="21" r="3" fill="white" opacity="0.18" />
+    </svg>
+  );
+}

--- a/src/components/Game/TrophyIcon.tsx
+++ b/src/components/Game/TrophyIcon.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+
+interface TrophyIconProps {
+  size?: number;
+  isDark?: boolean;
+  className?: string;
+}
+
+export function TrophyIcon({ size = 64, isDark = false, className }: TrophyIconProps) {
+  // 全字面 hex，不用 var()（SVG presentation attr 吃不到 CSS var）
+  const wine    = isDark ? '#c87080' : '#7b2d3a';
+  const gold    = isDark ? '#f0cc7a' : '#c9a84c';
+  const cupBody = isDark ? '#b06070' : '#8a3345';
+  const base    = isDark ? '#2a1f16' : '#f5efe0';
+
+  return (
+    <svg
+      viewBox="0 0 80 88"
+      width={size}
+      height={size}
+      style={{ display: 'block' }}
+      className={className}
+      aria-hidden="true"
+      role="img"
+    >
+      {/* ① 冠形杯口（3 尖頂，呼應 KingdomCrest 皇冠） */}
+      <path
+        d="M20 28 L26 14 L33 24 L40 10 L47 24 L54 14 L60 28 Z"
+        fill={gold}
+      />
+
+      {/* ② 冠帶（杯口腰線） */}
+      <rect x="18" y="27" width="44" height="7" rx="2" fill={gold} />
+      {/* 冠帶寶石：中央大顆 + 左右小顆 */}
+      <circle cx="40" cy="30.5" r="2.2" fill={wine} />
+      <circle cx="28" cy="30.5" r="1.4" fill={wine} opacity="0.8" />
+      <circle cx="52" cy="30.5" r="1.4" fill={wine} opacity="0.8" />
+
+      {/* ③ 杯身（上窄下寬梯形） */}
+      <path d="M22 34 L58 34 L54 56 L26 56 Z" fill={cupBody} />
+
+      {/* ④ 左把手（桂枝風格，純 stroke） */}
+      <path
+        d="M22 36 Q6 36 6 48 Q6 58 18 58"
+        fill="none"
+        stroke={gold}
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+      {/* ④ 右把手 */}
+      <path
+        d="M58 36 Q74 36 74 48 Q74 58 62 58"
+        fill="none"
+        stroke={gold}
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+
+      {/* ⑤ 杯腳（細頸） */}
+      <rect x="36" y="56" width="8" height="10" fill={gold} />
+
+      {/* ⑥ 底座 */}
+      <rect x="24" y="66" width="32" height="7" rx="3" fill={base} stroke={gold} strokeWidth="1.2" />
+
+      {/* ⑦ 桂冠葉裝飾（左右各 2 片，純 stroke） */}
+      {/* 左葉上 */}
+      <path
+        d="M20 40 Q10 36 11 44 Q12 50 20 48"
+        fill="none"
+        stroke={gold}
+        strokeWidth="1.2"
+        strokeLinecap="round"
+      />
+      {/* 左葉下 */}
+      <path
+        d="M20 46 Q8 44 10 52 Q12 58 20 55"
+        fill="none"
+        stroke={gold}
+        strokeWidth="1.2"
+        strokeLinecap="round"
+      />
+      {/* 右葉上 */}
+      <path
+        d="M60 40 Q70 36 69 44 Q68 50 60 48"
+        fill="none"
+        stroke={gold}
+        strokeWidth="1.2"
+        strokeLinecap="round"
+      />
+      {/* 右葉下 */}
+      <path
+        d="M60 46 Q72 44 70 52 Q68 58 60 55"
+        fill="none"
+        stroke={gold}
+        strokeWidth="1.2"
+        strokeLinecap="round"
+      />
+
+      {/* ⑧ 杯身中央刻紋（十字 + 圓環，呼應寶石語言） */}
+      <line x1="40" y1="39" x2="40" y2="51" stroke={gold} strokeWidth="0.8" opacity="0.6" />
+      <line x1="33" y1="45" x2="47" y2="45" stroke={gold} strokeWidth="0.8" opacity="0.6" />
+      <circle cx="40" cy="45" r="2" fill="none" stroke={gold} strokeWidth="0.8" opacity="0.7" />
+
+      {/* 尖頂明珠（呼應 KingdomCrest，有酒紅細描邊） */}
+      <circle cx="26" cy="12" r="2"   fill={gold} stroke={wine} strokeWidth="0.5" />
+      <circle cx="40" cy="8"  r="2.4" fill={gold} stroke={wine} strokeWidth="0.5" />
+      <circle cx="54" cy="12" r="2"   fill={gold} stroke={wine} strokeWidth="0.5" />
+    </svg>
+  );
+}

--- a/src/components/Game/TrophyIcon.tsx
+++ b/src/components/Game/TrophyIcon.tsx
@@ -62,40 +62,6 @@ export function TrophyIcon({ size = 64, isDark = false, className }: TrophyIconP
       {/* ⑥ 底座 */}
       <rect x="24" y="66" width="32" height="7" rx="3" fill={base} stroke={gold} strokeWidth="1.2" />
 
-      {/* ⑦ 桂冠葉裝飾（左右各 2 片，純 stroke） */}
-      {/* 左葉上 */}
-      <path
-        d="M20 40 Q10 36 11 44 Q12 50 20 48"
-        fill="none"
-        stroke={gold}
-        strokeWidth="1.2"
-        strokeLinecap="round"
-      />
-      {/* 左葉下 */}
-      <path
-        d="M20 46 Q8 44 10 52 Q12 58 20 55"
-        fill="none"
-        stroke={gold}
-        strokeWidth="1.2"
-        strokeLinecap="round"
-      />
-      {/* 右葉上 */}
-      <path
-        d="M60 40 Q70 36 69 44 Q68 50 60 48"
-        fill="none"
-        stroke={gold}
-        strokeWidth="1.2"
-        strokeLinecap="round"
-      />
-      {/* 右葉下 */}
-      <path
-        d="M60 46 Q72 44 70 52 Q68 58 60 55"
-        fill="none"
-        stroke={gold}
-        strokeWidth="1.2"
-        strokeLinecap="round"
-      />
-
       {/* ⑧ 杯身中央刻紋（十字 + 圓環，呼應寶石語言） */}
       <line x1="40" y1="39" x2="40" y2="51" stroke={gold} strokeWidth="0.8" opacity="0.6" />
       <line x1="33" y1="45" x2="47" y2="45" stroke={gold} strokeWidth="0.8" opacity="0.6" />

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -247,6 +247,33 @@
 }
 
 /* ----------------------------------------------------------
+ * R28 GameOver — TrophyIcon 金光脈衝（2.4s × 3 次後停止）
+ * 只用 filter:drop-shadow，不觸發 layout reflow
+ * ---------------------------------------------------------- */
+@keyframes trophyGlow {
+  0%   { filter: drop-shadow(0 0 0px #c9a84c00); }
+  50%  { filter: drop-shadow(0 0 8px #c9a84c99); }
+  100% { filter: drop-shadow(0 0 0px #c9a84c00); }
+}
+
+.animate-trophy-glow {
+  animation: trophyGlow 2.4s ease-in-out 3;
+}
+
+/* ----------------------------------------------------------
+ * R28 GameOver — 冠軍名字 shimmer（opacity 脈衝 1.6s × 2 次）
+ * ---------------------------------------------------------- */
+@keyframes championShimmer {
+  0%   { opacity: 1; }
+  50%  { opacity: 0.85; }
+  100% { opacity: 1; }
+}
+
+.animate-champion-shimmer {
+  animation: championShimmer 1.6s ease-in-out 2;
+}
+
+/* ----------------------------------------------------------
  * Accessibility: disable all animations when user prefers
  * reduced motion (WCAG 2.1 Success Criterion 2.3.3)
  * ---------------------------------------------------------- */
@@ -257,5 +284,13 @@
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+  }
+
+  /* R28 新增動畫明確 disable */
+  .animate-trophy-glow,
+  .animate-champion-shimmer {
+    animation: none;
+    opacity: 1;
+    filter: none;
   }
 }


### PR DESCRIPTION
## R28 GameOver 勝利畫面 3A 升級

CEO 讀碼發現:遊戲情緒高潮 GameOver 畫面靠 emoji 🏆/🥇🥈🥉,與 R26 精緻盾徽紋章質感斷層(延續 R27 emoji→自家美術弧線)。

### 內容
- **TrophyIcon.tsx**(新):冠形杯口(3 尖頂+明珠呼應 KingdomCrest)+酒紅杯身+金色 C 把手+羊皮紙底座+刻紋,全字面 hex
- **MedalIcon.tsx**(新):金/銀/銅三名次綬帶圓牌+名次數字,4 名以上純數字
- GameOver.tsx:🏆→TrophyIcon、🥇🥈🥉→MedalIcon,**保留 player.color/championColor/分數 bar/排名/i18n/onNewGame 全不動**
- 慶祝 juice:trophy-glow 金光脈衝+champion-shimmer,**全顧 prefers-reduced-motion(animation:none)**,只用 transform/opacity/filter

### CEO 親調
- CTO 初版獎盃桂葉裝飾與 C 把手疊在同側→雜亂像羊角捲軸。CEO 移除桂葉,留乾淨 C 把手,清楚讀作冠軍獎盃(特寫驗證 ~8/10)。

### 驗收
- ✅ 獎盃特寫(真實 SVG 渲染):金冠+酒紅杯身+乾淨把手,呼應紋章語言
- ✅ 完整 GameOver modal:Trophy+金銀銅 MedalIcon+冠軍玩家色名字+分數條(Light/Dark)
- ✅ SVG 全字面 hex 無 var 坑、reduced-motion 有 disable
- ✅ build 綠 / vitest 411(GameOver.test 6 過,無需改斷言) / eye 0 breaking
- ✅ 無 core/scoring/gameStore/multiplayer 異動
- ⚠️ 註:live GameOver 需玩到 settlements 用盡(殭屍 store 無法強制),已驗真實 SVG 輸出+整合測試通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)