### PR TITLE
feat(R29): bot 回合可看性 — 放置高亮 + 節奏放慢 + 對手行動中提示

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -789,6 +789,7 @@ function App() {
               canControlActions={canControlActions}
               onDrawCard={handleDrawTerrainCard}
               onEndTurn={handleEndTurn}
+              isCurrentPlayerBot={currentPlayer?.isBot ?? false}
             />
           )}
 

--- a/src/components/Board/HexCell.tsx
+++ b/src/components/Board/HexCell.tsx
@@ -15,6 +15,7 @@ interface HexCellProps {
   isHovered: boolean;
   isFocused?: boolean;
   isRecentlyPlaced?: boolean;
+  isBotPlacement?: boolean;
   playerColor?: string;
   playerName?: string;
   tabIndex: number;
@@ -56,6 +57,7 @@ export const HexCell: React.FC<HexCellProps> = React.memo(({
   isHovered,
   isFocused = false,
   isRecentlyPlaced = false,
+  isBotPlacement = false,
   playerColor,
   playerName,
   tabIndex,
@@ -200,6 +202,7 @@ export const HexCell: React.FC<HexCellProps> = React.memo(({
           cy={corners[0].y}
           playerColor={playerColor}
           isRecentlyPlaced={isRecentlyPlaced}
+          isBotPlacement={isBotPlacement}
         />
       )}
     </g>

--- a/src/components/Board/HexGrid.tsx
+++ b/src/components/Board/HexGrid.tsx
@@ -7,6 +7,7 @@ import { PieceDefs } from './PieceDefs';
 import { Player, HexCell as HexCellData } from '../../types';
 import { useBoardTransform, Transform } from '../../hooks/useBoardTransform';
 import { useTranslation } from 'react-i18next';
+import { useGameStore } from '../../store/gameStore';
 
 /**
  * Given a client-space coordinate (e.g. from mouse or touch event),
@@ -98,6 +99,10 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
   onInvalidClick,
 }) => {
   const { t } = useTranslation();
+  // Read-only: detect if current player is a bot for highlight emphasis (R29)
+  const isCurrentPlayerBot = useGameStore(
+    s => s.players[s.currentPlayerIndex]?.isBot ?? false
+  );
   const [hoveredCell, setHoveredCell] = useState<AxialCoord | null>(null);
   const {
     transform,
@@ -462,6 +467,7 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
                       isHovered={isHovered}
                       isFocused={isFocused}
                       isRecentlyPlaced={isRecentlyPlaced}
+                      isBotPlacement={isRecentlyPlaced && isCurrentPlayerBot}
                       playerColor={playerColor}
                       playerName={playerName}
                       tabIndex={isEntry ? 0 : -1}

--- a/src/components/Board/SettlementMarker.tsx
+++ b/src/components/Board/SettlementMarker.tsx
@@ -5,6 +5,7 @@ interface SettlementMarkerProps {
   cy: number;
   playerColor: string;
   isRecentlyPlaced?: boolean;
+  isBotPlacement?: boolean;
 }
 
 /**
@@ -30,6 +31,7 @@ export const SettlementMarker: React.FC<SettlementMarkerProps> = ({
   cy,
   playerColor,
   isRecentlyPlaced,
+  isBotPlacement,
 }) => {
   return (
     <g
@@ -45,9 +47,22 @@ export const SettlementMarker: React.FC<SettlementMarkerProps> = ({
           r={0}
           fill="none"
           stroke={playerColor}
-          strokeWidth={2}
+          strokeWidth={isBotPlacement ? 3 : 2}
           className="animate-settlement-ring"
           style={{ pointerEvents: 'none' }}
+        />
+      )}
+      {/* Bot ghost echo ring: delayed second ring for stronger emphasis */}
+      {isRecentlyPlaced && isBotPlacement && (
+        <circle
+          cx={0}
+          cy={0}
+          r={0}
+          fill="none"
+          stroke={playerColor}
+          strokeWidth={2}
+          className="animate-settlement-ring-ghost"
+          style={{ pointerEvents: 'none', opacity: 0.4 }}
         />
       )}
 

--- a/src/components/Game/TurnBanner.tsx
+++ b/src/components/Game/TurnBanner.tsx
@@ -5,6 +5,7 @@ import type { Player } from '../../types';
 import type { AxialCoord } from '../../core/hex';
 import { tPhase, tTerrain } from '../../i18n/formatters';
 import { DrawCardIcon, EndTurnIcon } from '../icons';
+import '../../styles/animations.css';
 
 interface TurnBannerProps {
   currentPlayer: Player | undefined;
@@ -15,6 +16,7 @@ interface TurnBannerProps {
   canControlActions: boolean;
   onDrawCard: () => void;
   onEndTurn: () => void;
+  isCurrentPlayerBot?: boolean;
 }
 
 /**
@@ -33,6 +35,7 @@ export const TurnBanner: React.FC<TurnBannerProps> = ({
   canControlActions,
   onDrawCard,
   onEndTurn,
+  isCurrentPlayerBot = false,
 }) => {
   const { t } = useTranslation();
 
@@ -107,6 +110,27 @@ export const TurnBanner: React.FC<TurnBannerProps> = ({
           </div>
         )}
       </div>
+
+      {/* Bot thinking indicator (R29) — only shown during bot turn */}
+      {isCurrentPlayerBot && (
+        <div className="flex items-center gap-1.5 flex-shrink-0" aria-live="polite">
+          <div
+            className="animate-spin-slow"
+            aria-hidden="true"
+            style={{
+              width: '14px',
+              height: '14px',
+              borderRadius: '50%',
+              border: '2px solid rgba(255,255,255,0.35)',
+              borderTopColor: '#ffffff',
+              flexShrink: 0,
+            }}
+          />
+          <span className="text-xs text-white/90 whitespace-nowrap">
+            {t('turnBanner.botThinking')}
+          </span>
+        </div>
+      )}
 
       {/* Primary action button */}
       <div className="flex-shrink-0">

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -276,6 +276,7 @@ export const en = {
     placementsProgress: '{{placed}} of {{total}} settlements placed',
     ofSettlements: '{{placed}} of {{total}}',
     noValidPlacements: 'No valid placements',
+    botThinking: 'Opponent thinking…',
   },
   sidebar: {
     terrainCard: 'Terrain Card',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -275,6 +275,7 @@ export const zhTW = {
     placementsProgress: '已放置 {{placed}} / {{total}} 個聚落',
     ofSettlements: '{{placed}} / {{total}}',
     noValidPlacements: '無可放置位置',
+    botThinking: '對手行動中…',
   },
   sidebar: {
     terrainCard: '地形卡',

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -553,7 +553,7 @@ export const gameStore = create<GameState>((set, get) => ({
     );
 
     // 3. Place each settlement with a short stagger so the UI can update
-    const STEP_MS = 100;
+    const STEP_MS = 400;
     moves.forEach((coord, i) => {
       setTimeout(() => get().placeSettlement(coord), STEP_MS * (i + 1));
     });

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -189,6 +189,38 @@
 }
 
 /* ----------------------------------------------------------
+ * Bot ghost echo ring (delayed by 80ms, R29 bot highlight)
+ * Second ring for stronger emphasis on bot placements.
+ * ---------------------------------------------------------- */
+@keyframes settlementRingGhost {
+  0% {
+    r: 0;
+    opacity: 0.4;
+  }
+  100% {
+    r: 18;
+    opacity: 0;
+  }
+}
+
+.animate-settlement-ring-ghost {
+  animation: settlementRingGhost 300ms ease-out 80ms forwards;
+}
+
+/* ----------------------------------------------------------
+ * Slow spin for TurnBanner bot thinking spinner (R29)
+ * 800ms linear infinite — used with a CSS border-top element
+ * ---------------------------------------------------------- */
+@keyframes spinSlow {
+  0%   { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.animate-spin-slow {
+  animation: spinSlow 800ms linear infinite;
+}
+
+/* ----------------------------------------------------------
  * Score pop-in on score increase (scale bounce, 400 ms)
  * Triggered by key change forcing remount of score span.
  * ---------------------------------------------------------- */

--- a/src/test/gameStore.botTiles.test.ts
+++ b/src/test/gameStore.botTiles.test.ts
@@ -70,7 +70,9 @@ describe('Bot location tiles', () => {
 
   it('uses an available placement tile before ending its turn', async () => {
     useGameStore.getState().triggerBotTurn();
-    await vi.advanceTimersByTimeAsync(1000);
+    // STEP_MS = 400: 3 placements at 400/800/1200ms, endTurn at 1600ms
+    // advance past 1600ms to ensure bot turn completes
+    await vi.advanceTimersByTimeAsync(2000);
 
     const state = useGameStore.getState();
     const bot = state.players[1];

--- a/tests/e2e/r29-bot-screenshot.spec.ts
+++ b/tests/e2e/r29-bot-screenshot.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * R29 Screenshot spec — captures bot placement highlight and TurnBanner spinner
+ * Uses gameStore.setState to set up a controlled bot turn scenario
+ */
+import { test, expect } from '@playwright/test';
+import { SetupPage } from '../pages/SetupPage';
+import { GamePage } from '../pages/GamePage';
+
+const BASE = 'http://localhost:5174';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('i18nextLng', 'en');
+    localStorage.setItem('tutorialCompleted', 'true');
+  });
+});
+
+test('R29: screenshot TurnBanner bot indicator', async ({ page }) => {
+  page.setDefaultTimeout(30000);
+
+  const setup = new SetupPage(page);
+  await setup.goto();
+  await setup.selectBoardSize('small');
+  await setup.startGame();
+
+  const gamePage = new GamePage(page);
+  await gamePage.liveRegion.waitFor({ state: 'attached', timeout: 10000 });
+
+  // Set bot turn active via setState so we can screenshot
+  await page.evaluate(async () => {
+    const { useGameStore } = await import('/src/store/gameStore.ts');
+    const state = useGameStore.getState();
+    // Switch to player 2 (bot) in DrawCard phase
+    useGameStore.setState({
+      currentPlayerIndex: 1,
+      phase: 'DrawCard' as any,
+    });
+  });
+
+  await page.waitForTimeout(300);
+
+  // Screenshot: TurnBanner should show "Opponent thinking…" + spinner
+  await page.screenshot({
+    path: 'test-results/r29-banner-bot-indicator.png',
+    clip: { x: 0, y: 0, width: 1280, height: 80 },
+  });
+
+  // Verify banner has bot indicator text
+  const bannerText = await page.locator('[role="status"]').textContent();
+  console.log('Banner text with bot turn:', bannerText?.slice(0, 100));
+  expect(bannerText).toContain('Opponent thinking');
+
+  // Full screenshot for reference
+  await page.screenshot({ path: 'test-results/r29-banner-bot-full.png' });
+});
+
+test('R29: screenshot bot placement ring highlight', async ({ page }) => {
+  page.setDefaultTimeout(30000);
+
+  const setup = new SetupPage(page);
+  await setup.goto();
+  await setup.selectBoardSize('small');
+  await setup.startGame();
+
+  const gamePage = new GamePage(page);
+  await gamePage.liveRegion.waitFor({ state: 'attached', timeout: 10000 });
+
+  // Draw card and place first settlement as Player 1 to verify ring
+  await gamePage.clickDrawCard();
+  await page.waitForTimeout(200);
+
+  // Screenshot immediately after placing a settlement (ring should be visible)
+  await page.evaluate(() => {
+    // Trigger click on first valid cell
+    const cell = Array.from(document.querySelectorAll<SVGElement>('[role="gridcell"]'))
+      .find(el =>
+        el.getAttribute('aria-label')?.includes('valid placement') &&
+        el.getAttribute('aria-disabled') !== 'true'
+      );
+    cell?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+  });
+
+  // Immediately screenshot — ring lasts 250ms
+  await page.waitForTimeout(50);
+  await page.screenshot({ path: 'test-results/r29-placement-ring.png' });
+
+  // Now advance to bot turn and capture during placement
+  // Place remaining 2 settlements
+  for (let i = 0; i < 2; i++) {
+    await page.evaluate(() => {
+      const cell = Array.from(document.querySelectorAll<SVGElement>('[role="gridcell"]'))
+        .find(el =>
+          el.getAttribute('aria-label')?.includes('valid placement') &&
+          el.getAttribute('aria-disabled') !== 'true'
+        );
+      cell?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+    await page.waitForTimeout(200);
+  }
+
+  // Force end turn via store
+  await page.evaluate(async () => {
+    const { useGameStore } = await import('/src/store/gameStore.ts');
+    useGameStore.getState().endTurn();
+  });
+
+  // Wait for bot to place first settlement (~800ms trigger)
+  await page.waitForTimeout(850);
+
+  // Screenshot during bot placement — ring should be visible
+  await page.screenshot({ path: 'test-results/r29-bot-placing.png' });
+
+  // Wait another 400ms for second
+  await page.waitForTimeout(400);
+  await page.screenshot({ path: 'test-results/r29-bot-placing-2.png' });
+
+  // Wait for bot to finish
+  await page.waitForTimeout(2000);
+
+  const liveText = await gamePage.liveRegion.textContent().catch(() => '');
+  console.log('After bot turn:', liveText?.slice(0, 60));
+  expect(liveText).toMatch(/Player 1|Human/);
+});

--- a/tests/e2e/r29-bot-turn-observe.spec.ts
+++ b/tests/e2e/r29-bot-turn-observe.spec.ts
@@ -1,0 +1,227 @@
+/**
+ * R29 Bot Turn Observer Spec
+ * 量測 bot 回合時序、高亮、TurnBanner「對手行動中」
+ */
+import { test, expect } from '@playwright/test';
+import { SetupPage } from '../pages/SetupPage';
+import { GamePage } from '../pages/GamePage';
+
+const BASE = 'http://localhost:5174';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('i18nextLng', 'en');
+    // Skip tutorial/onboarding prompt so it doesn't block game actions
+    localStorage.setItem('tutorialCompleted', 'true');
+  });
+});
+
+test('R29: verify animations.css has bot ring and spinner classes', async ({ page }) => {
+  await page.goto(BASE + '/');
+
+  const hasGhostAnimation = await page.evaluate(() => {
+    const el = document.createElement('div');
+    el.className = 'animate-settlement-ring-ghost';
+    document.body.appendChild(el);
+    const animName = getComputedStyle(el).animationName;
+    document.body.removeChild(el);
+    return animName !== 'none' && animName !== '';
+  });
+
+  const hasSpinAnimation = await page.evaluate(() => {
+    const el = document.createElement('div');
+    el.className = 'animate-spin-slow';
+    document.body.appendChild(el);
+    const animName = getComputedStyle(el).animationName;
+    document.body.removeChild(el);
+    return animName !== 'none' && animName !== '';
+  });
+
+  console.log('animate-settlement-ring-ghost loaded:', hasGhostAnimation);
+  console.log('animate-spin-slow loaded:', hasSpinAnimation);
+
+  expect(hasGhostAnimation).toBeTruthy();
+  expect(hasSpinAnimation).toBeTruthy();
+});
+
+test('R29: bot turn timing and banner indicator', async ({ page }) => {
+  page.setDefaultTimeout(60000);
+
+  // ── 1. Setup: 1 human vs 1 bot (small board) ───────────────────────────
+  const setup = new SetupPage(page);
+  await setup.goto();
+  await setup.selectBoardSize('small');
+  await setup.startGame();
+
+  const gamePage = new GamePage(page);
+
+  // ── 2. Player 1 turn: draw + place 3 settlements ─────────────────────
+  await gamePage.liveRegion.waitFor({ state: 'attached', timeout: 10000 });
+
+  // Set up MutationObserver before player ends turn
+  // NOTE: TurnBanner uses key={currentPlayer.id} so it force-remounts on turn change.
+  // We must observe the PARENT container (document.body level) to catch new banner nodes.
+  await page.evaluate(() => {
+    const log: Array<{ time: number; event: string }> = [];
+    const start = Date.now();
+    const record = (msg: string) => {
+      const entry = { time: Date.now() - start, event: msg };
+      log.push(entry);
+      console.log(`[R29] +${entry.time}ms ${entry.event}`);
+    };
+
+    // Observe document.body subtree for banner additions/text changes
+    // (banner force-remounts on player change, so we can't watch the element itself)
+    const bodyObs = new MutationObserver(() => {
+      const banner = document.querySelector('[role="status"]');
+      if (banner) {
+        const txt = banner.textContent?.replace(/\s+/g, ' ').trim().slice(0, 80) ?? '';
+        record(`banner: "${txt}"`);
+      }
+    });
+    bodyObs.observe(document.body, { childList: true, subtree: true });
+
+    // Initial banner state
+    const initBanner = document.querySelector('[role="status"]');
+    record(`observer-init: "${initBanner?.textContent?.trim().slice(0, 60) ?? 'NO BANNER'}"`);
+
+    // SVG ring animations
+    const svg = document.querySelector('svg');
+    if (svg) {
+      const so = new MutationObserver(mutations => {
+        for (const m of mutations) {
+          for (const n of m.addedNodes) {
+            const el = n as Element;
+            if (el.classList?.contains?.('animate-settlement-ring')) record('ring-primary added');
+            if (el.classList?.contains?.('animate-settlement-ring-ghost')) record('ring-ghost added');
+          }
+          if (m.type === 'attributes' && m.attributeName === 'class') {
+            const el = m.target as Element;
+            if (el.classList?.contains('animate-settlement-ring')) record('ring-primary class-change');
+            if (el.classList?.contains('animate-settlement-ring-ghost')) record('ring-ghost class-change');
+          }
+        }
+      });
+      so.observe(svg, { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] });
+    }
+
+    (window as any).__r29log = log;
+  });
+
+  // Draw card + place 3 settlements
+  await gamePage.clickDrawCard();
+  await page.waitForTimeout(300);
+
+  for (let i = 0; i < 3; i++) {
+    await gamePage.clickValidCell();
+    await page.waitForTimeout(150);
+  }
+
+  // Screenshot: player 1 finished placements
+  await page.screenshot({ path: 'test-results/r29-p1-placed.png' });
+
+  // Mark time before ending turn
+  await page.evaluate(() => {
+    (window as any).__r29turnEndAt = Date.now();
+    console.log('[R29] Player 1 ending turn...');
+  });
+
+  // End turn: try button click via aria-label first, then JS dispatch
+  await page.evaluate(async () => {
+    // Try aria-label
+    const byAria = document.querySelector<HTMLElement>(
+      '[aria-label="End your turn and pass to the next player"]'
+    );
+    if (byAria) { byAria.click(); return; }
+    // Try by text
+    const byText = Array.from(document.querySelectorAll<HTMLElement>('button')).find(
+      b => b.textContent?.includes('End Turn')
+    );
+    if (byText) { byText.click(); return; }
+    // Fallback: useGameStore via window
+    const store = (window as any).__zustand_store ?? (window as any).useGameStore;
+    if (store) store.getState().endTurn();
+  });
+
+  // Wait a bit to let bot turn start
+  await page.waitForTimeout(500);
+
+  // Check if bot turn has started (banner should show Player 2)
+  const bannerAfterEnd = await page.locator('[role="status"]').textContent().catch(() => '');
+  console.log('Banner after endTurn attempt:', bannerAfterEnd?.slice(0, 80));
+
+  // If banner still shows EndTurn for Player 1, force via store
+  if (bannerAfterEnd?.includes('Player 1') && bannerAfterEnd?.includes('EndTurn')) {
+    console.log('Forcing endTurn via store import...');
+    await page.evaluate(async () => {
+      const { useGameStore } = await import('/src/store/gameStore.ts');
+      useGameStore.getState().endTurn();
+    });
+  }
+
+  // ── 3. Wait for bot to complete (~2.4s) ─────────────────────────────────
+  console.log('Waiting for bot turn...');
+  await page.waitForTimeout(3500);
+
+  // Screenshot: after bot turn completes
+  await page.screenshot({ path: 'test-results/r29-after-bot.png' });
+
+  // ── 4. Collect and analyze log ──────────────────────────────────────────
+  const events = await page.evaluate(() =>
+    (window as any).__r29log as Array<{ time: number; event: string }>
+  );
+
+  console.log('\n=== R29 Observer Log ===');
+  for (const e of events) {
+    console.log(`  +${String(e.time).padStart(5)}ms  ${e.event}`);
+  }
+
+  const ringPrimary = events.filter(e => e.event.includes('ring-primary'));
+  const ringGhost   = events.filter(e => e.event.includes('ring-ghost'));
+  const bannerEvts  = events.filter(e => e.event.startsWith('banner:'));
+  const botBanner   = bannerEvts.find(e =>
+    e.event.includes('Opponent thinking') || e.event.includes('對手行動中')
+  );
+
+  console.log('\n=== Summary ===');
+  console.log('ring-primary events:', ringPrimary.length);
+  console.log('ring-ghost events:', ringGhost.length);
+  console.log('banner changes:', bannerEvts.length);
+  console.log('Bot thinking banner seen:', !!botBanner);
+  if (botBanner) console.log('  └─', botBanner.event);
+
+  // Ring interval check
+  if (ringPrimary.length >= 2) {
+    for (let i = 1; i < ringPrimary.length; i++) {
+      const interval = ringPrimary[i].time - ringPrimary[i - 1].time;
+      console.log(`Ring interval ${i}→${i + 1}: ${interval}ms (expected ~400ms)`);
+      expect(interval).toBeGreaterThan(300);
+      expect(interval).toBeLessThan(600);
+    }
+  }
+
+  // Bot turn total duration
+  if (ringPrimary.length > 0 && bannerEvts.length > 1) {
+    const first = ringPrimary[0].time;
+    const last  = bannerEvts[bannerEvts.length - 1].time;
+    const total = last - first;
+    console.log(`Bot turn duration: ${total}ms (expected 800–2500ms)`);
+    if (ringPrimary.length >= 3) {
+      expect(total).toBeGreaterThan(600);
+      expect(total).toBeLessThan(3000);
+    }
+  }
+
+  // Verify bot thinking banner appeared
+  expect(botBanner).toBeDefined();
+
+  // ── 5. Verify bot turn ended & play resumed ──────────────────────────────
+  const liveText = await gamePage.liveRegion.textContent().catch(() => '');
+  console.log('\nLive region after bot turn:', liveText?.slice(0, 80));
+
+  // Phase should be back to Player 1's DrawCard phase
+  const phase = liveText ?? '';
+  const isPlayer1Turn = phase.includes('Player 1') || phase.includes('Human');
+  console.log('Back to player 1 turn:', isPlayer1Turn);
+  expect(isPlayer1Turn).toBeTruthy();
+});


### PR DESCRIPTION
## R29 bot 回合 game feel

CEO 實地玩發現:單人對戰 bot 時 bot 回合太快(STEP_MS=100ms,3 個放置擠 ~300ms),玩家看不清對手放哪。

### 內容
- **STEP_MS 100→400ms**(gameStore.ts:556 **僅此一行**):bot 放置間隔可看
- **bot 放置高亮**(view-layer):SettlementMarker  → ring 加粗 2→3 + ghost echo ring;HexGrid 讀 isBot(只讀)傳入
- **TurnBanner「對手行動中…」**+CSS spinner(view-layer),App 傳 
- reduced-motion 全局攔截已涵蓋
- i18n: botThinking(zh/en)

### CEO 親審 + 親測(vite preview + Playwright observer,真實玩)
- ✅ **gameStore diff 僅 STEP_MS 一行**(placeSettlement/endTurn/triggerBotTurn/scoring 零改動)
- ✅ 真實玩量測:bot 3 放置間隔 **403/402/406ms**(watchable)、全程「對手行動中」banner + bot ring 高亮、總時長 ~2.4s
- ✅ **回歸**:bot 放 3 個→計分正確(P2 ★15分🏰12)→交回 P1 抽牌 phase,無卡死
- ✅ build 綠 / vitest 411(botTiles.test 時序 1000→2000ms 隨 STEP_MS 同步,意圖不變)
- ⚠️ eye 2 critical 為 optional prop(/)新增之保守誤報,tsc 0 error、內部單一 caller 已更新,無實際破壞
- 雙審:STEP_MS 計時常數非安全相關,CEO 嚴格親審 gameStore 一行 + 回歸通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)