### PR TITLE
feat(R30): 無效放置視覺回饋 — shake + 紅閃 + 規則提示 toast

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import { LocationTileCard, LocationTileIcon } from './components/Game/LocationTi
 import { GamePhase } from './types'
 import type { PlayerConfig, GameOptions } from './types'
 import type { Board } from './core/board'
-import { Location } from './core/terrain'
+import { Location, isBuildable } from './core/terrain'
 import { scoreCastle, scoreObjectiveCard } from './core/scoring'
 import { initAudio, playSound, isMuted, setMuted, SoundType } from './utils/soundEngine'
 import { InstallPrompt } from './components/InstallPrompt'
@@ -34,6 +34,7 @@ import { useLeaderboardStore } from './store/leaderboardStore'
 import { ReplayModal } from './components/Game/ReplayModal'
 import { AchievementPanel } from './components/Game/AchievementPanel'
 import { AchievementToast } from './components/Game/AchievementToast'
+import { InvalidHintToast } from './components/Game/InvalidHintToast'
 import { useAchievementStore, getUnlockedCount } from './store/achievementStore'
 import { SeasonBanner } from './components/Game/SeasonBanner'
 import { SeasonHistory } from './components/Game/SeasonHistory'
@@ -122,6 +123,45 @@ function ScoreRow({ playerId, playerName, playerColor, total, isLeader, summaryT
       </p>
     </div>
   );
+}
+
+/**
+ * R30: Derive a human-readable hint message explaining why a cell is invalid.
+ * Pure function — reads gameStore via getState() (safe in event handler context,
+ * does NOT subscribe and will NOT cause re-renders).
+ * Only imports isBuildable for read-only terrain check; never touches rules.ts actions.
+ */
+function deriveInvalidHint(
+  coord: { q: number; r: number },
+  t: ReturnType<typeof useTranslation>['t'],
+): string {
+  const { board, currentTerrainCard, placementsThisTurn } = useGameStore.getState();
+  if (!board || !currentTerrainCard) return t('hint.invalid.not_valid');
+
+  const cell = board.getCell(coord);
+  if (!cell) return t('hint.invalid.not_valid');
+
+  // Priority 1: cell already occupied
+  if (cell.settlement !== undefined) {
+    return t('hint.invalid.occupied');
+  }
+
+  // Priority 2: unbuildable terrain (Mountain / Water)
+  if (!isBuildable(cell.terrain)) {
+    return t('hint.invalid.terrain_unbuildable', { terrain: tTerrain(t, cell.terrain) });
+  }
+
+  // Priority 3: terrain doesn't match current card
+  if (cell.terrain !== currentTerrainCard.terrain) {
+    return t('hint.invalid.wrong_terrain', { terrain: tTerrain(t, currentTerrainCard.terrain) });
+  }
+
+  // Priority 4: adjacency rule (subsequent placements must be adjacent to earlier ones)
+  if (placementsThisTurn.length > 0) {
+    return t('hint.invalid.must_be_adjacent');
+  }
+
+  return t('hint.invalid.not_valid');
 }
 
 function App() {
@@ -435,17 +475,30 @@ function App() {
     }
   }
 
-  // INVALID: play sound when clicking a non-valid cell during PlaceSettlements
+  // INVALID: play sound + show visual feedback when clicking a non-valid cell
   const invalidClickTimestampRef = useRef(0);
+  const [invalidClickKey, setInvalidClickKey] = useState<string | null>(null);
+  const [invalidHintMsg, setInvalidHintMsg] = useState<string | null>(null);
+  const invalidHintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleInvalidCellClick = (_coord: { q: number; r: number }) => {
+  const handleInvalidCellClick = (coord: { q: number; r: number }) => {
     if (!canControlActions) return;
     if (phase !== GamePhase.PlaceSettlements) return;   // 只在放聚落相響
     const now = Date.now();
     if (now - invalidClickTimestampRef.current < 100) return;
     invalidClickTimestampRef.current = now;
-    console.log('[sound] INVALID click');
+
+    // 1. 保留既有音效
     playSound(SoundType.INVALID);
+
+    // 2. 視覺 shake/flash
+    setInvalidClickKey(`${coord.q},${coord.r}`);
+
+    // 3. hint toast：推導無效原因，1800ms 後自動消失
+    const hint = deriveInvalidHint(coord, t);
+    if (invalidHintTimerRef.current) clearTimeout(invalidHintTimerRef.current);
+    setInvalidHintMsg(hint);
+    invalidHintTimerRef.current = setTimeout(() => setInvalidHintMsg(null), 1800);
   };
 
   const liveScores = players.map(p => ({
@@ -816,6 +869,7 @@ function App() {
                 onCellSelect={selectCell}
                 onEscape={handleEscape}
                 onInvalidClick={handleInvalidCellClick}
+                invalidClickKey={invalidClickKey}
               />
               </div>
             )}
@@ -1372,6 +1426,9 @@ function App() {
 
       {/* Achievement unlock toast notification */}
       <AchievementToast />
+
+      {/* R30: Invalid placement hint toast */}
+      <InvalidHintToast message={invalidHintMsg} />
 
       {/* Quit-to-menu confirmation modal */}
       <QuitToMenuConfirmModal

--- a/src/components/Board/HexCell.tsx
+++ b/src/components/Board/HexCell.tsx
@@ -16,6 +16,8 @@ interface HexCellProps {
   isFocused?: boolean;
   isRecentlyPlaced?: boolean;
   isBotPlacement?: boolean;
+  /** R30: true for 400ms when an invalid click lands on this cell */
+  isInvalidFlash?: boolean;
   playerColor?: string;
   playerName?: string;
   tabIndex: number;
@@ -58,6 +60,7 @@ export const HexCell: React.FC<HexCellProps> = React.memo(({
   isFocused = false,
   isRecentlyPlaced = false,
   isBotPlacement = false,
+  isInvalidFlash = false,
   playerColor,
   playerName,
   tabIndex,
@@ -140,6 +143,7 @@ export const HexCell: React.FC<HexCellProps> = React.memo(({
       onMouseLeave={onMouseLeave}
       onFocus={onFocus}
       onKeyDown={onKeyDown}
+      className={isInvalidFlash ? 'animate-hex-invalid-shake' : undefined}
       style={{ cursor: isValid ? 'pointer' : 'default' }}
     >
       {/* 底色漸層 polygon（hover 時用直值 #FFFF99，非 hover 用共用 gradient 變體） */}
@@ -183,6 +187,19 @@ export const HexCell: React.FC<HexCellProps> = React.memo(({
           <polygon points={points} fill="none" stroke="#1a1410" strokeWidth={5} opacity={0.85} pointerEvents="none" />
           <polygon points={points} fill="none" stroke="#FFD24A" strokeWidth={2.5} pointerEvents="none" />
         </>
+      )}
+
+      {/* R30: invalid click red stroke flash overlay */}
+      {isInvalidFlash && (
+        <polygon
+          points={points}
+          fill="none"
+          stroke="#CC2200"
+          strokeWidth={3.5}
+          opacity={0}
+          pointerEvents="none"
+          className="animate-hex-invalid-flash"
+        />
       )}
 
       {/* Show location marker if present */}

--- a/src/components/Board/HexGrid.tsx
+++ b/src/components/Board/HexGrid.tsx
@@ -82,6 +82,8 @@ interface HexGridProps {
   onEditCellPaint?: (coord: AxialCoord) => void;
   editMode?: 'paint' | 'pan';
   onInvalidClick?: (coord: AxialCoord) => void;
+  /** R30: "q,r" key of the most-recently invalid-clicked cell; drives shake/flash */
+  invalidClickKey?: string | null;
 }
 
 export const HexGrid: React.FC<HexGridProps> = React.memo(({
@@ -97,6 +99,7 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
   onEditCellPaint,
   editMode = 'paint',
   onInvalidClick,
+  invalidClickKey,
 }) => {
   const { t } = useTranslation();
   // Read-only: detect if current player is a bot for highlight emphasis (R29)
@@ -129,6 +132,17 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
   const svgRef = useRef<SVGSVGElement>(null);
 
   const cells = board.getAllCells();
+
+  // ── R30: track which invalid-clicked cell should shake/flash ─────────────
+  const [invalidFlashKey, setInvalidFlashKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!invalidClickKey) return;
+    setInvalidFlashKey(invalidClickKey);
+    const timer = setTimeout(() => setInvalidFlashKey(null), 400);
+    return () => clearTimeout(timer);
+  }, [invalidClickKey]);
+  // ──────────────────────────────────────────────────────────────────────────
 
   // ── UI-only: track the most recently placed settlement cell ────────────────
   // We compare the set of settlement keys before/after board changes.
@@ -457,6 +471,7 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
                   const key = `${cell.coord.q},${cell.coord.r}`;
                   const isEntry = entryCoord !== null && hexEquals(cell.coord, entryCoord);
                   const isRecentlyPlaced = recentlyPlacedKey === key;
+                  const isInvalidFlash = invalidFlashKey === key;
 
                   return (
                     <HexCell
@@ -468,6 +483,7 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
                       isFocused={isFocused}
                       isRecentlyPlaced={isRecentlyPlaced}
                       isBotPlacement={isRecentlyPlaced && isCurrentPlayerBot}
+                      isInvalidFlash={isInvalidFlash}
                       playerColor={playerColor}
                       playerName={playerName}
                       tabIndex={isEntry ? 0 : -1}

--- a/src/components/Game/InvalidHintToast.tsx
+++ b/src/components/Game/InvalidHintToast.tsx
@@ -1,0 +1,37 @@
+/**
+ * R30: Lightweight hint toast shown when a player clicks an invalid cell
+ * during the PlaceSettlements phase. Explains *why* the placement is invalid.
+ *
+ * - Controlled entirely by App.tsx state (message / null).
+ * - Auto-dismiss timer lives in App; this component is purely presentational.
+ * - pointer-events-none so it never blocks board interaction.
+ * - aria-live="polite" ensures screen readers announce the hint.
+ */
+
+interface InvalidHintToastProps {
+  message: string | null;
+}
+
+export function InvalidHintToast({ message }: InvalidHintToastProps) {
+  if (!message) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className="fixed bottom-36 left-1/2 -translate-x-1/2 z-50 animate-hint-toast-in pointer-events-none"
+    >
+      <div
+        className="rounded-xl shadow-lg px-4 py-2.5 text-sm font-medium text-center max-w-[16rem]"
+        style={{
+          background: 'var(--toast-bg)',
+          color: 'var(--toast-text)',
+          border: '1px solid var(--toast-border)',
+        }}
+      >
+        {message}
+      </div>
+    </div>
+  );
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -311,6 +311,15 @@ export const en = {
     settlementSuffix: '{{player}} settlement',
     validPlacementSuffix: 'valid placement',
   },
+  hint: {
+    invalid: {
+      occupied: 'This cell is already occupied',
+      terrain_unbuildable: 'Cannot place on {{terrain}}',
+      wrong_terrain: 'Must place on {{terrain}} this turn',
+      must_be_adjacent: 'Must place next to a settlement from this turn',
+      not_valid: 'Cannot place here',
+    },
+  },
   installPrompt: {
     ariaLabel: 'Install to home screen',
     button: '📲 Install to home screen',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -309,6 +309,15 @@ export const zhTW = {
     settlementSuffix: '{{player}} 的聚落',
     validPlacementSuffix: '可放置',
   },
+  hint: {
+    invalid: {
+      occupied: '此格已有聚落',
+      terrain_unbuildable: '無法在{{terrain}}放置聚落',
+      wrong_terrain: '本回合須放在{{terrain}}地形',
+      must_be_adjacent: '須相鄰本回合已放的聚落',
+      not_valid: '無法在此放置',
+    },
+  },
   installPrompt: {
     ariaLabel: '安裝到主畫面',
     button: '📲 安裝到主畫面',

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -306,6 +306,56 @@
 }
 
 /* ----------------------------------------------------------
+ * R30 Invalid cell shake (X ±3px, 400ms)
+ * transform-box + transform-origin ensure the shake pivots
+ * around the hex cell centre rather than the SVG origin.
+ * ---------------------------------------------------------- */
+@keyframes hexInvalidShake {
+  0%   { transform: translateX(0); }
+  15%  { transform: translateX(-3px); }
+  30%  { transform: translateX(3px); }
+  45%  { transform: translateX(-3px); }
+  60%  { transform: translateX(3px); }
+  75%  { transform: translateX(-2px); }
+  90%  { transform: translateX(1px); }
+  100% { transform: translateX(0); }
+}
+
+.animate-hex-invalid-shake {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: hexInvalidShake 400ms ease-out both;
+}
+
+/* ----------------------------------------------------------
+ * R30 Invalid cell red stroke flash (opacity 0.85 → 0, 400ms)
+ * Applied to an overlay polygon inside HexCell.
+ * ---------------------------------------------------------- */
+@keyframes hexInvalidFlash {
+  0%   { opacity: 0.85; }
+  60%  { opacity: 0.5; }
+  100% { opacity: 0; }
+}
+
+.animate-hex-invalid-flash {
+  animation: hexInvalidFlash 400ms ease-out forwards;
+}
+
+/* ----------------------------------------------------------
+ * R30 Hint toast slide-in (translateY 6px→0, opacity 0→1, 180ms)
+ * translateX(-50%) preserved in every keyframe to maintain
+ * the Tailwind -translate-x-1/2 horizontal centring.
+ * ---------------------------------------------------------- */
+@keyframes hintToastIn {
+  0%   { transform: translateX(-50%) translateY(6px); opacity: 0; }
+  100% { transform: translateX(-50%) translateY(0);   opacity: 1; }
+}
+
+.animate-hint-toast-in {
+  animation: hintToastIn 180ms ease-out both;
+}
+
+/* ----------------------------------------------------------
  * Accessibility: disable all animations when user prefers
  * reduced motion (WCAG 2.1 Success Criterion 2.3.3)
  * ---------------------------------------------------------- */

--- a/tests/e2e/r30-invalid-feedback.spec.ts
+++ b/tests/e2e/r30-invalid-feedback.spec.ts
@@ -1,0 +1,256 @@
+import { test, expect, Page } from '@playwright/test';
+
+async function startGame(page: Page) {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Single Player' }).click();
+  await page.getByRole('button', { name: 'Start Game' }).click();
+  // Skip onboarding/tutorial if shown
+  const skipBtn = page.getByRole('button', { name: /skip/i });
+  if (await skipBtn.isVisible({ timeout: 1500 }).catch(() => false)) {
+    await skipBtn.click();
+  }
+}
+
+async function drawCard(page: Page) {
+  // Use aria-label to target the TurnBanner draw button specifically
+  const drawBtn = page.getByRole('button', { name: 'Draw terrain card to start your turn' }).first();
+  await drawBtn.waitFor({ state: 'visible', timeout: 10000 });
+  await drawBtn.click();
+}
+
+test.describe('R30 invalid placement visual feedback', () => {
+  test('A: invalid click shows hint toast + shake class on clicked cell', async ({ page }) => {
+    await startGame(page);
+    await drawCard(page);
+
+    // Wait for PlaceSettlements — at least one valid cell should appear
+    const validCell = page.locator('[role="gridcell"][aria-disabled="false"]').first();
+    await validCell.waitFor({ timeout: 8000 });
+
+    // Register observer before clicking, click inside the same evaluate call
+    const { shakeDetected, hintToastText } = await page.evaluate(async () => {
+      return new Promise<{ shakeDetected: boolean; hintToastText: string }>((resolve) => {
+        let shakeFound = false;
+        const deadline = setTimeout(() => {
+          observer.disconnect();
+          // Check for hint toast text at timeout
+          const statuses = document.querySelectorAll('[role="status"][aria-live="polite"]');
+          let toastTxt = '';
+          statuses.forEach(el => {
+            const t = el.textContent ?? '';
+            if (t && (t.includes('place') || t.includes('terrain') || t.includes('adjacent') ||
+                t.includes('occupied') || t.includes('放') || t.includes('須') || t.includes('格'))) {
+              toastTxt = t;
+            }
+          });
+          resolve({ shakeDetected: shakeFound, hintToastText: toastTxt });
+        }, 1500);
+
+        const observer = new MutationObserver((mutations) => {
+          for (const m of mutations) {
+            if (m.type === 'attributes' && m.attributeName === 'class') {
+              const el = m.target as Element;
+              const cn = el.getAttribute('class') ?? '';
+              if (cn.includes('animate-hex-invalid-shake')) {
+                shakeFound = true;
+              }
+            }
+          }
+        });
+
+        const svg = document.querySelector('svg');
+        if (svg) {
+          observer.observe(svg, { subtree: true, attributes: true, attributeFilter: ['class'] });
+        }
+
+        // Click invalid cell
+        const invalidCells = document.querySelectorAll('[role="gridcell"][aria-disabled="true"]');
+        if (invalidCells.length > 0) {
+          const target = invalidCells[0] as HTMLElement;
+          target.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+          // After React re-render, also poll the DOM directly for the shake class
+          const pollInterval = setInterval(() => {
+            const shakeEls = document.querySelectorAll('.animate-hex-invalid-shake');
+            if (shakeEls.length > 0) {
+              shakeFound = true;
+              clearInterval(pollInterval);
+            }
+          }, 16); // poll every frame
+          setTimeout(() => clearInterval(pollInterval), 1400);
+        }
+      });
+    });
+
+    // Wait for React to render toast
+    await page.waitForTimeout(400);
+
+    // Also check via Playwright locator for redundancy
+    const toasts = page.locator('[role="status"][aria-live="polite"]');
+    const toastCount = await toasts.count();
+    let hintToastVisible = hintToastText !== '';
+    let finalToastText = hintToastText;
+    for (let i = 0; i < toastCount; i++) {
+      const txt = await toasts.nth(i).textContent();
+      if (txt && (
+        txt.includes('place') || txt.includes('terrain') || txt.includes('adjacent') ||
+        txt.includes('occupied') || txt.includes('放') || txt.includes('須') || txt.includes('格')
+      )) {
+        hintToastVisible = true;
+        finalToastText = txt;
+        break;
+      }
+    }
+
+    console.log('shakeDetected:', shakeDetected, '| hintToastVisible:', hintToastVisible, '| toast:', finalToastText);
+
+    // Take screenshot for CEO review
+    await page.screenshot({ path: '/tmp/r30-invalid-flash-toast.png', fullPage: false });
+
+    // Toast must appear
+    expect(hintToastVisible).toBe(true);
+    // Shake should also be detected (via MutationObserver)
+    expect(shakeDetected).toBe(true);
+  });
+
+  test('B: valid placement does NOT trigger shake animation', async ({ page }) => {
+    await startGame(page);
+    await drawCard(page);
+
+    const validCell = page.locator('[role="gridcell"][aria-disabled="false"]').first();
+    await validCell.waitFor({ timeout: 8000 });
+
+    // Watch for invalid shake BEFORE clicking a valid cell
+    const invalidShakeOnValid = await page.evaluate(async () => {
+      return new Promise<boolean>((resolve) => {
+        let found = false;
+        const deadline = setTimeout(() => resolve(found), 1000);
+
+        const observer = new MutationObserver((mutations) => {
+          for (const m of mutations) {
+            if (m.type === 'attributes' && m.attributeName === 'class') {
+              const el = m.target as Element;
+              const cn = el.getAttribute('class') ?? '';
+              if (cn.includes('animate-hex-invalid-shake')) {
+                found = true;
+                clearTimeout(deadline);
+                observer.disconnect();
+                resolve(true);
+                return;
+              }
+            }
+          }
+        });
+
+        const svg = document.querySelector('svg');
+        if (svg) observer.observe(svg, { subtree: true, attributes: true, attributeFilter: ['class'] });
+
+        // Click a VALID cell
+        const validCells = document.querySelectorAll('[role="gridcell"][aria-disabled="false"]');
+        if (validCells.length > 0) {
+          (validCells[0] as HTMLElement).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        } else {
+          clearTimeout(deadline);
+          resolve(false);
+        }
+      });
+    });
+
+    console.log('invalidShakeOnValid:', invalidShakeOnValid);
+    await page.screenshot({ path: '/tmp/r30-valid-placement-ok.png', fullPage: false });
+    expect(invalidShakeOnValid).toBe(false);
+  });
+
+  test('C: debounce — 5 rapid clicks produce fewer than 5 shake triggers', async ({ page }) => {
+    await startGame(page);
+    await drawCard(page);
+
+    const validCell = page.locator('[role="gridcell"][aria-disabled="false"]').first();
+    await validCell.waitFor({ timeout: 8000 });
+
+    const shakeCount = await page.evaluate(async () => {
+      return new Promise<number>((resolve) => {
+        let count = 0;
+
+        const obs = new MutationObserver((mutations) => {
+          for (const m of mutations) {
+            if (m.type === 'attributes' && m.attributeName === 'class') {
+              const el = m.target as Element;
+              const cn = el.getAttribute('class') ?? '';
+              if (cn.includes('animate-hex-invalid-shake')) {
+                count++;
+              }
+            }
+          }
+        });
+
+        const svg = document.querySelector('svg');
+        if (svg) obs.observe(svg, { subtree: true, attributes: true, attributeFilter: ['class'] });
+
+        const invalidCells = document.querySelectorAll('[role="gridcell"][aria-disabled="true"]');
+        const target = invalidCells[0] as HTMLElement;
+        if (target) {
+          for (let i = 0; i < 5; i++) {
+            target.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+          }
+        }
+
+        setTimeout(() => {
+          obs.disconnect();
+          resolve(count);
+        }, 800);
+      });
+    });
+
+    console.log('shakeCount for 5 rapid clicks:', shakeCount);
+    // Debounce should prevent 5 separate triggers; expect fewer than 5
+    expect(shakeCount).toBeLessThan(5);
+  });
+
+  test('D: hint toast auto-dismisses after ~1800ms', async ({ page }) => {
+    await startGame(page);
+    await drawCard(page);
+
+    const validCell = page.locator('[role="gridcell"][aria-disabled="false"]').first();
+    await validCell.waitFor({ timeout: 8000 });
+
+    // Trigger invalid click
+    await page.evaluate(() => {
+      const invalidCells = document.querySelectorAll('[role="gridcell"][aria-disabled="true"]');
+      if (invalidCells.length > 0) {
+        (invalidCells[0] as HTMLElement).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      }
+    });
+
+    await page.waitForTimeout(300);
+    // Toast should be visible now
+    const toasts = page.locator('[role="status"][aria-live="polite"]');
+    let toastTextBefore = '';
+    const count = await toasts.count();
+    for (let i = 0; i < count; i++) {
+      const txt = await toasts.nth(i).textContent();
+      if (txt && (txt.includes('place') || txt.includes('terrain') || txt.includes('放') || txt.includes('須'))) {
+        toastTextBefore = txt;
+        break;
+      }
+    }
+
+    // Wait for auto-dismiss (1800ms + buffer)
+    await page.waitForTimeout(2200);
+
+    // Toast should be gone (null message → null render)
+    let toastStillThere = false;
+    const countAfter = await toasts.count();
+    for (let i = 0; i < countAfter; i++) {
+      const txt = await toasts.nth(i).textContent();
+      if (txt && txt === toastTextBefore && toastTextBefore !== '') {
+        toastStillThere = true;
+        break;
+      }
+    }
+
+    console.log('toastTextBefore:', toastTextBefore, '| toastStillThere after 2.2s:', toastStillThere);
+    expect(toastTextBefore).not.toBe('');
+    expect(toastStillThere).toBe(false);
+  });
+});


### PR DESCRIPTION
## R30 無效放置回饋（UX/a11y）

CEO 實地玩發現:點無效格放聚落時**只播 INVALID 音效、零視覺回饋**——玩家靜音/音效未初始化(瀏覽器需 user gesture)就不知為何放不下去;聽障/靜音玩家零提示(a11y 缺口)。

### 內容
- **被點無效格 shake + 紅 stroke 閃**(仿 recentlyPlacedKey 機制,invalidFlashKey 400ms,新 keyframe, 修原點)
- **規則提示 hint toast**(InvalidHintToast, 唯讀判斷原因:已佔據/不可建/地形不符/相鄰限制 → 「只能放在【X】地形」,1800ms 自動消,重用 toast token,)
- 保留 INVALID 音效、維持 100ms debounce
- i18n(zh+en)

### CEO 親審 + 真實玩親測(vite preview + Playwright observer)
- ✅ 無效點擊:observer 真實捕捉  + 紅  閃 + hint toast(CTO 截圖「Cannot place on Mountain」)
- ✅ **有效點擊不誤觸發**(validClickTriggeredShake:false)+ 聚落正常放上
- ✅ debounce 防狂閃、reduced-motion 不降級(shake 不播但 toast aria-live 仍顯示)
- ✅ **core/gameStore.ts 零邏輯改動**(deriveInvalidHint 只 getState()+isBuildable 唯讀)
- ✅ build 綠 / vitest 411 / eye 0 breaking
- 安全雙審:純 view 回饋,不觸發

🤖 Generated with [Claude Code](https://claude.com/claude-code)