### PR TITLE
fix(build): 修復 tsc -b 型別錯誤，恢復 npm run build / docker 建置（老闆不能玩根因）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,7 +72,7 @@ function usePrevious<T>(value: T): T | undefined {
 }
 
 interface ScoreRowProps {
-  playerId: string;
+  playerId: number;
   playerName: string | undefined;
   playerColor: string;
   total: number;

--- a/src/components/Game/MedalIcon.tsx
+++ b/src/components/Game/MedalIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 interface MedalIconProps {
   rank: 1 | 2 | 3;

--- a/src/components/Game/TrophyIcon.tsx
+++ b/src/components/Game/TrophyIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 interface TrophyIconProps {
   size?: number;

--- a/src/components/icons/AchievementBadge.tsx
+++ b/src/components/icons/AchievementBadge.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 // ────────────────────────────────────────────────────
 // AchievementIconKey union type（exportしてstore/typesで使用）

--- a/src/store/seasonStore.ts
+++ b/src/store/seasonStore.ts
@@ -209,5 +209,5 @@ export const useSeasonStore = create<SeasonState>((set, get) => ({
 // NOTE: test-only, allows injecting history data via browser console
 // e.g. window.__seasonStore.getState().checkAndRotateSeason(new Date('2026-05-01'))
 if (typeof window !== 'undefined' && import.meta.env.DEV) {
-  (window as Record<string, unknown>).__seasonStore = useSeasonStore;
+  (window as unknown as Record<string, unknown>).__seasonStore = useSeasonStore;
 }

--- a/src/test/HexGrid.recentlyPlaced.test.tsx
+++ b/src/test/HexGrid.recentlyPlaced.test.tsx
@@ -8,12 +8,11 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, act } from '@testing-library/react';
-import React from 'react';
 
 import { HexGrid } from '../components/Board/HexGrid';
 import { Board } from '../core/board';
 import { Terrain } from '../core/terrain';
-import { BotDifficulty, GamePhase } from '../types';
+import { BotDifficulty } from '../types';
 import type { Player } from '../types';
 
 // ─── helpers ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 緊急修復：老闆「連基本操作都不能玩」根因

`npm run build` = `tsc -b && vite build`，但 CTO/CEO 驗證都只用 `vite build` / `tsc --noEmit`（**跳過 `tsc -b`**），TypeScript 錯誤跨輪累積，**docker production build（`npm run build`）失敗** → 老闆 docker 環境（8087）建不起來/過時 → 不能玩。

### 修復的 tsc 錯誤
- `App.tsx` ScoreRowProps.playerId: `string` → `number`（player id 本是 number，TS2322）
- `MedalIcon`/`TrophyIcon`/`AchievementBadge` 移除未使用的 `import React`（R28/R31 留下，TS6133）
- `seasonStore` `window as Record` → `window as unknown as Record`（TS2352）
- `HexGrid.recentlyPlaced.test` 移除未用 React/GamePhase import

### 驗證
- ✅ `npm run build` exit 0（tsc -b + vite build 都過）
- ✅ vitest 411 全過
- ✅ 下一步：重建 docker 8087 恢復老闆環境

### 教訓
驗證一律用 `npm run build`（含 tsc -b），不能只用 vite build。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
