### PR TITLE
feat(R32): 功能 UI emoji → 既有 SVG icon（玩家/電腦 toggle、城堡計分）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,7 @@ import {
   AchievementIcon,
   ExitIcon,
 } from './components/icons'
+import { CastleIcon } from './components/icons/CastleIcon'
 
 const STATE_BROADCAST_DEBOUNCE_MS = 50;
 
@@ -118,7 +119,8 @@ function ScoreRow({ playerId, playerName, playerColor, total, isLeader, summaryT
           {total} {pointsLabel}
         </span>
       </div>
-      <p className="text-xs mt-0.5" style={{ color: 'var(--color-stone-400)' }}>
+      <p className="text-xs mt-0.5 inline-flex items-center gap-1" style={{ color: 'var(--color-stone-400)' }}>
+        <CastleIcon size={11} aria-hidden="true" />
         {summaryText}
       </p>
     </div>

--- a/src/components/Game/GameSetup.tsx
+++ b/src/components/Game/GameSetup.tsx
@@ -6,6 +6,8 @@ import { useTranslation } from 'react-i18next';
 import { useCustomMapStore } from '../../mapEditor/customMapStore';
 import { decode } from '../../mapEditor/codec';
 import { payloadToBoard } from '../../mapEditor/payloadToBoard';
+import { HumanIcon } from '../icons/HumanIcon';
+import { BotIcon } from '../icons/BotIcon';
 
 interface GameSetupProps {
   onStart: (configs: PlayerConfig[], options: GameOptions, customBoard?: Board) => void;
@@ -240,7 +242,12 @@ export function GameSetup({ onStart, onBack }: GameSetupProps) {
                         : { backgroundColor: 'var(--color-warm-cream-200)', color: 'var(--color-stone-700)' }
                     }
                   >
-                    {type === 'human' ? t('setup.human') : t('setup.computer')}
+                    <span className="inline-flex items-center gap-1.5">
+                      {type === 'human'
+                        ? <HumanIcon size={14} />
+                        : <BotIcon size={14} />}
+                      {type === 'human' ? t('setup.human') : t('setup.computer')}
+                    </span>
                   </button>
                 ))}
               </div>

--- a/src/components/Mobile/BottomDrawer.tsx
+++ b/src/components/Mobile/BottomDrawer.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { tObjective, tPhase, tTerrain } from '../../i18n/formatters';
 import { ObjectiveCardBadge } from '../Game/ObjectiveCardBadge';
 import { LocationTileCard } from '../Game/LocationTileCard';
+import { CastleIcon } from '../icons/CastleIcon';
 
 interface BottomDrawerProps {
   isOpen: boolean;
@@ -374,7 +375,8 @@ export const BottomDrawer: React.FC<BottomDrawerProps> = ({
                           {total} {t('common.pointsShort')}
                         </span>
                       </div>
-                      <p className="text-xs mt-0.5" style={{ color: 'var(--color-stone-400)' }}>
+                      <p className="text-xs mt-0.5 inline-flex items-center gap-1" style={{ color: 'var(--color-stone-400)' }}>
+                        <CastleIcon size={11} aria-hidden="true" />
                         {t('app.castleScoreSummary', {
                           castle: playerScore.castle,
                           objectives: playerScore.objectives

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -167,7 +167,7 @@ export const en = {
     playerListAria:
       '{{name}}: {{placed}} placed, {{remaining}} remaining{{isCurrent}}',
     playerListAriaCurrentSuffix: ', current player',
-    castleScoreSummary: '🏰 {{castle}} | {{objectives}}',
+    castleScoreSummary: '{{castle}} | {{objectives}}',
     objectiveScoreItem: '{{card}}: {{score}}',
   },
   setup: {
@@ -175,8 +175,8 @@ export const en = {
     numberOfPlayers: 'Number of Players',
     playerLabel: 'Player {{number}}',
     playerPlaceholder: 'Player {{number}}',
-    human: '🧑 Human',
-    computer: '🤖 Computer',
+    human: 'Human',
+    computer: 'Computer',
     aiDifficulty: 'AI Difficulty',
     difficultyEasy: 'Easy (Random)',
     difficultyMedium: 'Medium (Strategic)',
@@ -200,10 +200,10 @@ export const en = {
     customMapMultiplayerNote: 'Custom maps are not supported in multiplayer mode.',
   },
   gameOver: {
-    heading: '🏆 Game Over!',
+    heading: 'Game Over!',
     finalRankings: 'Final Rankings',
-    castleScore: '🏰 Castle: {{score}} pts',
-    objectiveScore: '🎯 {{card}}: {{score}} pts',
+    castleScore: 'Castle: {{score}} pts',
+    objectiveScore: '{{card}}: {{score}} pts',
     castleSegment: 'Castle',
     segmentScore: '{{label}}: {{score}} pts',
     scoreBarAriaLabel: '{{player}} score breakdown, {{score}} total points',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -166,7 +166,7 @@ export const zhTW = {
     playerListAria:
       '{{name}}：已放置 {{placed}}，剩餘 {{remaining}}{{isCurrent}}',
     playerListAriaCurrentSuffix: '，目前玩家',
-    castleScoreSummary: '🏰 {{castle}} | {{objectives}}',
+    castleScoreSummary: '{{castle}} | {{objectives}}',
     objectiveScoreItem: '{{card}}：{{score}}',
   },
   setup: {
@@ -174,8 +174,8 @@ export const zhTW = {
     numberOfPlayers: '玩家人數',
     playerLabel: '玩家 {{number}}',
     playerPlaceholder: '玩家 {{number}}',
-    human: '🧑 玩家',
-    computer: '🤖 電腦',
+    human: '玩家',
+    computer: '電腦',
     aiDifficulty: 'AI 難度',
     difficultyEasy: '簡單（隨機）',
     difficultyMedium: '中等（策略）',
@@ -199,10 +199,10 @@ export const zhTW = {
     customMapMultiplayerNote: '多人模式不支援自訂地圖',
   },
   gameOver: {
-    heading: '🏆 遊戲結束！',
+    heading: '遊戲結束！',
     finalRankings: '最終排名',
-    castleScore: '🏰 城堡：{{score}} 分',
-    objectiveScore: '🎯 {{card}}：{{score}} 分',
+    castleScore: '城堡：{{score}} 分',
+    objectiveScore: '{{card}}：{{score}} 分',
     castleSegment: '城堡',
     segmentScore: '{{label}}：{{score}} 分',
     scoreBarAriaLabel: '{{player}} 得分分解，總分 {{score}} 分',

--- a/src/test/mobile.test.tsx
+++ b/src/test/mobile.test.tsx
@@ -261,7 +261,7 @@ describe('BottomDrawer', () => {
     expect(within(liveScores).getByText('Alice')).toBeTruthy();
     expect(within(liveScores).getByText(/10\s+pts/)).toBeTruthy();
     expect(within(liveScores).getByTitle('Leading')).toBeTruthy();
-    expect(within(liveScores).getByText('🏰 3 | Hermits: 5 | Farmers: 2')).toBeTruthy();
+    expect(within(liveScores).getByText(/3 \| Hermits: 5 \| Farmers: 2/)).toBeTruthy();
   });
 
   it('does not show live scores during setup phase', () => {


### PR DESCRIPTION
## R32 功能 UI emoji → 既有 SVG（收尾 emoji→自家美術 arc）

功能 UI 仍有 emoji,複用既有 icon 統一:
- 玩家/電腦 toggle `🧑`/`🤖` → `<HumanIcon>`/`<BotIcon>`
- 即時計分/BottomDrawer 城堡分數 `🏰` → `<CastleIcon size=11>`(兩個渲染點)
- GameOver heading `🏆` 去冗餘(TrophyIcon 已在上方)
- dead key `🏰🎯` 順手去 emoji
- 教學內文 emoji 不動

### 驗證（已 merge hotfix df17aa8，用新標準）
- ✅ **`npm run build` exit 0（含 tsc -b，非只 vite build）** / vitest 411 / eye 0
- ✅ CEO 親測:setup toggle SVG、計分列 CastleIcon、無 emoji 殘留、backward compat 不涉
- ✅ 複用既有 HumanIcon/BotIcon/CastleIcon、純呈現、不碰 scoring/gameStore/core

🤖 Generated with [Claude Code](https://claude.com/claude-code)
