### PR TITLE
feat(R33): code-splitting — lazy load MapEditor/Replay/Leaderboard/SeasonHistory

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, lazy, Suspense } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useGameStore } from './store/gameStore'
 import { HexGrid } from './components/Board/HexGrid'
@@ -29,19 +29,17 @@ import { extractSerializableState } from './multiplayer/stateSerializer'
 import type { MultiplayerAction } from './multiplayer/types'
 import { useTranslation } from 'react-i18next'
 import { tObjective, tPhase, tTerrain } from './i18n/formatters'
-import { LeaderboardModal } from './components/Game/LeaderboardModal'
 import { useLeaderboardStore } from './store/leaderboardStore'
-import { ReplayModal } from './components/Game/ReplayModal'
 import { AchievementPanel } from './components/Game/AchievementPanel'
 import { AchievementToast } from './components/Game/AchievementToast'
 import { InvalidHintToast } from './components/Game/InvalidHintToast'
 import { useAchievementStore, getUnlockedCount } from './store/achievementStore'
 import { SeasonBanner } from './components/Game/SeasonBanner'
-import { SeasonHistory } from './components/Game/SeasonHistory'
 import { TerrainSwatch } from './components/Game/TerrainSwatch'
 import { BoardFrameOverlay } from './components/Board/BoardFrameOverlay'
 import { useSeasonStore } from './store/seasonStore'
-import { MapEditorPage } from './components/MapEditor/MapEditorPage'
+import { PageLoadingFallback } from './components/UI/PageLoadingFallback'
+import { ModalLoadingFallback } from './components/UI/ModalLoadingFallback'
 import {
   MutedIcon,
   UnmutedIcon,
@@ -57,6 +55,19 @@ import {
   ExitIcon,
 } from './components/icons'
 import { CastleIcon } from './components/icons/CastleIcon'
+
+const MapEditorPage = lazy(() =>
+  import('./components/MapEditor/MapEditorPage').then(m => ({ default: m.MapEditorPage }))
+)
+const LeaderboardModal = lazy(() =>
+  import('./components/Game/LeaderboardModal').then(m => ({ default: m.LeaderboardModal }))
+)
+const ReplayModal = lazy(() =>
+  import('./components/Game/ReplayModal').then(m => ({ default: m.ReplayModal }))
+)
+const SeasonHistory = lazy(() =>
+  import('./components/Game/SeasonHistory').then(m => ({ default: m.SeasonHistory }))
+)
 
 const STATE_BROADCAST_DEBOUNCE_MS = 50;
 
@@ -590,7 +601,11 @@ function App() {
 
   if (!gameStarted) {
     if (menuMode === 'map-editor') {
-      return <MapEditorPage onBack={() => setMenuMode('home')} />;
+      return (
+        <Suspense fallback={<PageLoadingFallback />}>
+          <MapEditorPage onBack={() => setMenuMode('home')} />
+        </Suspense>
+      );
     }
 
     if (menuMode === 'multiplayer') {
@@ -636,8 +651,16 @@ function App() {
           onLanguageChange={(lang) => void i18n.changeLanguage(lang)}
           onMapEditor={() => setMenuMode('map-editor')}
         />
-        <LeaderboardModal isOpen={leaderboardOpen} onClose={() => setLeaderboardOpen(false)} />
-        <SeasonHistory isOpen={seasonHistoryOpen} onClose={() => setSeasonHistoryOpen(false)} />
+        {leaderboardOpen && (
+          <Suspense fallback={<ModalLoadingFallback />}>
+            <LeaderboardModal isOpen={leaderboardOpen} onClose={() => setLeaderboardOpen(false)} />
+          </Suspense>
+        )}
+        {seasonHistoryOpen && (
+          <Suspense fallback={<ModalLoadingFallback />}>
+            <SeasonHistory isOpen={seasonHistoryOpen} onClose={() => setSeasonHistoryOpen(false)} />
+          </Suspense>
+        )}
         <TutorialOverlay />
       </>
     );
@@ -1409,20 +1432,32 @@ function App() {
         />
       )}
 
-      <LeaderboardModal
-        isOpen={leaderboardOpen}
-        onClose={() => setLeaderboardOpen(false)}
-      />
+      {leaderboardOpen && (
+        <Suspense fallback={<ModalLoadingFallback />}>
+          <LeaderboardModal
+            isOpen={leaderboardOpen}
+            onClose={() => setLeaderboardOpen(false)}
+          />
+        </Suspense>
+      )}
 
-      <SeasonHistory
-        isOpen={seasonHistoryOpen}
-        onClose={() => setSeasonHistoryOpen(false)}
-      />
+      {seasonHistoryOpen && (
+        <Suspense fallback={<ModalLoadingFallback />}>
+          <SeasonHistory
+            isOpen={seasonHistoryOpen}
+            onClose={() => setSeasonHistoryOpen(false)}
+          />
+        </Suspense>
+      )}
 
-      <ReplayModal
-        isOpen={replayOpen}
-        onClose={() => setReplayOpen(false)}
-      />
+      {replayOpen && (
+        <Suspense fallback={<ModalLoadingFallback />}>
+          <ReplayModal
+            isOpen={replayOpen}
+            onClose={() => setReplayOpen(false)}
+          />
+        </Suspense>
+      )}
 
       {achievementOpen && <AchievementPanel onClose={() => setAchievementOpen(false)} />}
 

--- a/src/components/Menu/MainMenu.tsx
+++ b/src/components/Menu/MainMenu.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, lazy, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { loadGame, clearSave } from '../../store/persistence';
 import { gameStore } from '../../store/gameStore';
@@ -18,9 +18,15 @@ import {
   PlayIcon,
   ConnectedIcon,
 } from '../icons';
-import { LeaderboardModal } from '../Game/LeaderboardModal';
-import { ReplayModal } from '../Game/ReplayModal';
 import { AchievementPanel } from '../Game/AchievementPanel';
+import { ModalLoadingFallback } from '../UI/ModalLoadingFallback';
+
+const LeaderboardModal = lazy(() =>
+  import('../Game/LeaderboardModal').then(m => ({ default: m.LeaderboardModal }))
+)
+const ReplayModal = lazy(() =>
+  import('../Game/ReplayModal').then(m => ({ default: m.ReplayModal }))
+)
 import { SettingsModal } from './SettingsModal';
 import { getVolume, setVolume } from '../../utils/soundEngine';
 
@@ -339,8 +345,16 @@ export function MainMenu({
       </div>
 
       {/* Modals */}
-      <LeaderboardModal isOpen={leaderboardOpen} onClose={() => setLeaderboardOpen(false)} />
-      <ReplayModal isOpen={replayOpen} onClose={() => setReplayOpen(false)} />
+      {leaderboardOpen && (
+        <Suspense fallback={<ModalLoadingFallback />}>
+          <LeaderboardModal isOpen={leaderboardOpen} onClose={() => setLeaderboardOpen(false)} />
+        </Suspense>
+      )}
+      {replayOpen && (
+        <Suspense fallback={<ModalLoadingFallback />}>
+          <ReplayModal isOpen={replayOpen} onClose={() => setReplayOpen(false)} />
+        </Suspense>
+      )}
       {achievementOpen && <AchievementPanel onClose={() => setAchievementOpen(false)} />}
       <SettingsModal
         isOpen={settingsOpen}

--- a/src/components/UI/ModalLoadingFallback.tsx
+++ b/src/components/UI/ModalLoadingFallback.tsx
@@ -1,0 +1,18 @@
+export function ModalLoadingFallback() {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ backgroundColor: 'oklch(0 0 0 / 0.4)' }}
+    >
+      <div
+        className="rounded-2xl p-8 flex flex-col items-center gap-3"
+        style={{ backgroundColor: 'var(--color-surface)', boxShadow: 'var(--shadow-medium)' }}
+      >
+        <div
+          className="w-8 h-8 rounded-full border-2 animate-spin"
+          style={{ borderColor: 'var(--button-primary-bg)', borderTopColor: 'transparent' }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/UI/PageLoadingFallback.tsx
+++ b/src/components/UI/PageLoadingFallback.tsx
@@ -1,0 +1,21 @@
+export function PageLoadingFallback() {
+  return (
+    <div
+      className="w-screen h-screen flex items-center justify-center"
+      style={{ backgroundColor: 'var(--color-bg)' }}
+    >
+      <div
+        className="flex flex-col items-center gap-3"
+        style={{ color: 'var(--color-stone-500)' }}
+      >
+        <div
+          className="w-8 h-8 rounded-full border-2 animate-spin"
+          style={{ borderColor: 'var(--button-primary-bg)', borderTopColor: 'transparent' }}
+        />
+        <span className="text-sm" style={{ fontFamily: 'var(--font-display)' }}>
+          Loading…
+        </span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## R33 code-splitting（工程成熟度/載入效能）

罕用重型畫面用 `React.lazy` + Suspense 拆獨立 chunk，按需載入：
- **MapEditor**(13KB,整個編輯器,多數玩家不用) + **Replay**(9.5KB) + **Leaderboard**(4KB) + **SeasonHistory**(2KB)
- AchievementPanel 不拆(78 行太小)
- modal 從常駐 `isOpen=false` 掛載 → `{open && <Suspense>}` 條件渲染(真 lazy 效益)
- 順手修 MainMenu 也靜態 import modal(會擋拆分)
- 2 個主題化 fallback(PageLoadingFallback/ModalLoadingFallback)

### 效益
初始 bundle 583.78→556.59 KB(gzip 157.62→151.91，-5.7KB)。降幅務實(主 bundle 大頭是第三方 lib)，但**架構正確**:4 個畫面按需載入,不再塞給不用的玩家。

### CEO 親審 + 親測(npm run build + Playwright，修正後標準)
- ✅ **`npm run build` exit 0(含 tsc -b，非只 vite build)** / vitest 411 / eye 0
- ✅ 初始只載 index.js;點開才下載對應 chunk(performance.getEntriesByType 驗證)
- ✅ MapEditor lazy 載入+渲染**無白屏**、排行榜 modal lazy 載入+開+**關閉正常**、回放 modal lazy(含 replayStore)+開
- ✅ modal 條件渲染改動沒壞 open/close
- ✅ 無 core/scoring/gameStore/multiplayer 改動(只改載入方式)
- 安全雙審:純載入機制,不觸發

🤖 Generated with [Claude Code](https://claude.com/claude-code)
