### PR TITLE
feat(R34): vendor chunk splitting — 拆 react/i18n vendor，主 bundle -43%、消除 500KB 警告

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,30 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          // vendor-react: react core 三件套（緊耦合，務必同組避免拆散導致 undefined export 白屏）
+          if (
+            id.includes('node_modules/react-dom/') ||
+            id.includes('node_modules/react/') ||
+            id.includes('node_modules/scheduler/')
+          ) {
+            return 'vendor-react'
+          }
+          // vendor-i18n: 國際化 + 狀態管理
+          if (
+            id.includes('node_modules/i18next/') ||
+            id.includes('node_modules/react-i18next/') ||
+            id.includes('node_modules/zustand/')
+          ) {
+            return 'vendor-i18n'
+          }
+        },
+      },
+    },
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## R34 vendor chunk splitting（工程成熟度，延續 R33）

R33 後主 bundle 仍 556KB + 500KB 警告(第三方 lib 擠一起)。用 vite `manualChunks`(function 形式)拆 vendor:
- **vendor-react**(react/react-dom/scheduler 緊耦合保持同組避免白屏)
- **vendor-i18n**(i18next/react-i18next/zustand)

### 效益（npm run build 前後對比）
- 主 app chunk 556→**313KB(-43%)**、vendor-react 192KB、vendor-i18n 49KB
- **500KB 警告消失**
- app 更新時 vendor chunk hash 不變→瀏覽器快取命中,玩家只重抓小 app chunk(重複載入更快)

### CEO 親審 + 親測(npm run build + Playwright)
- ✅ `npm run build` exit 0(含 tsc -b) / vitest 411 / eye 0
- ✅ **無白屏**(vendor 拆分關鍵風險,rootInnerHTML 17003)、選單渲染、vendor-react+vendor-i18n+index 3 chunks 都載入
- ✅ 遊戲流程+切語言正常(CTO 驗)
- ✅ diff 只 vite.config.ts(24 行)、不碰 app 程式碼/game logic
- 安全雙審:純 build config,不觸發

🤖 Generated with [Claude Code](https://claude.com/claude-code)
