### PR TITLE
feat(R35): 遊戲區棋盤改用 PixiJS + pixi-viewport（根治反覆互動 bug）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "autoprefixer": "^10.4.24",
         "i18next": "^26.0.4",
+        "pixi-viewport": "^6.0.3",
+        "pixi.js": "^8.18.1",
         "postcss": "^8.5.6",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -1267,6 +1269,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@pixi/colord": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
+      "license": "MIT"
+    },
     "node_modules/@playwright/test": {
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
@@ -2071,6 +2079,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/earcut": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-3.0.0.tgz",
+      "integrity": "sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2543,6 +2557,21 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.70.tgz",
+      "integrity": "sha512-LFiNHHKMvmAEvwVew3JLJmTdShhbdwRFSImUshGhE2mGE8ybQzIo63l5uRp+YKnNx+8Qno8Kf6gN+DKMreIJCA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2987,6 +3016,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
@@ -3286,6 +3321,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3429,6 +3470,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/gifuct-js": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gifuct-js/-/gifuct-js-2.1.2.tgz",
+      "integrity": "sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==",
+      "license": "MIT",
+      "dependencies": {
+        "js-binary-schema-parser": "^2.0.3"
       }
     },
     "node_modules/glob-parent": {
@@ -3657,6 +3707,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -3666,6 +3722,12 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-binary-schema-parser": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/js-binary-schema-parser/-/js-binary-schema-parser-2.0.3.tgz",
+      "integrity": "sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4265,6 +4327,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
@@ -4323,6 +4391,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pixi-viewport": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/pixi-viewport/-/pixi-viewport-6.0.3.tgz",
+      "integrity": "sha512-2+qPJ0/n+8hQYhWvY+795+x9y3MiUrCOWacK0DY53whowWaGdx9iDocy7z1pBwjkZhC52YvrJQuZKK0sdVLtBw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pixi.js": ">=8"
+      }
+    },
+    "node_modules/pixi.js": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.18.1.tgz",
+      "integrity": "sha512-6LUPWYgulZhp/w4kam2XHXB0QedISZIqrJbRdHLLQ3csn5a38uzKxAp6B5j6s89QFYaIJbg95kvgTRcbgpO1ow==",
+      "license": "MIT",
+      "peer": true,
+      "workspaces": [
+        "examples",
+        "playground"
+      ],
+      "dependencies": {
+        "@pixi/colord": "^2.9.6",
+        "@types/earcut": "^3.0.0",
+        "@webgpu/types": "^0.1.69",
+        "@xmldom/xmldom": "^0.8.12",
+        "earcut": "^3.0.2",
+        "eventemitter3": "^5.0.1",
+        "gifuct-js": "^2.1.2",
+        "ismobilejs": "^1.1.1",
+        "parse-svg-path": "^0.1.2",
+        "tiny-lru": "^11.4.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
       }
     },
     "node_modules/playwright": {
@@ -4761,6 +4865,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tiny-lru": {
+      "version": "11.4.7",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.4.7.tgz",
+      "integrity": "sha512-w/Te7uMUVeH0CR8vZIjr+XiN41V+30lkDdK+NRIDCUYKKuL9VcmaUEmaPISuwGhLlrTGh5yu18lENtR9axSxYw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "autoprefixer": "^10.4.24",
     "i18next": "^26.0.4",
+    "pixi-viewport": "^6.0.3",
+    "pixi.js": "^8.18.1",
     "postcss": "^8.5.6",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, lazy, Suspense } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useGameStore } from './store/gameStore'
-import { HexGrid } from './components/Board/HexGrid'
+import { PixiBoard } from './components/Board/PixiBoard'
 import { GameOver } from './components/Game/GameOver'
 import { GameLog } from './components/Game/GameLog'
 import { BottomDrawer } from './components/Mobile/BottomDrawer'
@@ -525,10 +525,6 @@ function App() {
   const currentPlayerObjectiveScores =
     liveScores.find(playerScore => playerScore.playerId === currentPlayer?.id)?.objectives ?? []
 
-  const handleEscape = () => {
-    selectCell(null);
-  };
-
   const handleRestart = () => {
     if (isNetworkGame) {
       leaveRoom();
@@ -881,7 +877,7 @@ function App() {
           >
             {players.length > 0 && (
               <div className="w-full h-full" data-tutorial-target="hex-grid">
-              <HexGrid
+              <PixiBoard
                 board={board}
                 validPlacements={
                   activeTile && (activeTile === Location.Paddock || activeTile === Location.Barn)
@@ -892,7 +888,6 @@ function App() {
                 players={players}
                 onCellClick={handleCellClick}
                 onCellSelect={selectCell}
-                onEscape={handleEscape}
                 onInvalidClick={handleInvalidCellClick}
                 invalidClickKey={invalidClickKey}
               />

--- a/src/components/Board/PixiBoard.tsx
+++ b/src/components/Board/PixiBoard.tsx
@@ -1,0 +1,512 @@
+/**
+ * PixiBoard — R35 Phase 1
+ * WebGL-based hex board using PixiJS v8 + pixi-viewport v6.
+ * Replaces the SVG HexGrid in the game view to eliminate:
+ *   - click swallowed by pan (threshold:5 in drag plugin)
+ *   - focus ring (canvas has no DOM focus indicator)
+ *   - zoom jitter (pixi-viewport handles pinch/wheel math)
+ *
+ * Phase 1 scope: functional rendering only (flat colours, no R24 art).
+ * MapEditor still uses the old HexGrid (Phase 2).
+ */
+
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import { Application, Graphics, Container } from 'pixi.js';
+import { Viewport } from 'pixi-viewport';
+import type { Board } from '../../core/board';
+import type { AxialCoord } from '../../core/hex';
+import { HEX_SIZE, hexToKey, pixelToAxial } from '../../core/hex';
+import type { Player } from '../../types';
+import { Location } from '../../core/terrain';
+import { getTerrainColor } from '../../core/terrain';
+import {
+  cssColorToPixi,
+  drawHex,
+  drawHexBorder,
+  drawSettlementCircle,
+  drawCastleMarker,
+  drawLocationDot,
+} from './pixiHexUtils';
+import { useTranslation } from 'react-i18next';
+
+// ─── Location indicator colours (functional, not R24 art) ───────────────────
+const LOCATION_COLORS: Record<string, number> = {
+  [Location.Farm]:    0x8BC34A,
+  [Location.Oasis]:   0x00BCD4,
+  [Location.Tower]:   0x9E9E9E,
+  [Location.Harbor]:  0x1565C0,
+  [Location.Paddock]: 0x795548,
+  [Location.Barn]:    0xF57F17,
+  [Location.Oracle]:  0x7B1FA2,
+  [Location.Tavern]:  0xE53935,
+};
+
+// ─── Props ───────────────────────────────────────────────────────────────────
+export interface PixiBoardProps {
+  board: Board;
+  validPlacements: AxialCoord[];
+  selectedCell: AxialCoord | null;
+  players: Player[];
+  onCellClick: (coord: AxialCoord) => void;
+  onCellSelect: (coord: AxialCoord | null) => void;
+  onInvalidClick?: (coord: AxialCoord) => void;
+  invalidClickKey?: string | null;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+export const PixiBoard: React.FC<PixiBoardProps> = ({
+  board,
+  validPlacements,
+  selectedCell,
+  players,
+  onCellClick,
+  onCellSelect,
+  onInvalidClick,
+  invalidClickKey,
+}) => {
+  const { t } = useTranslation();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  // Refs to Pixi objects — NOT state to avoid re-render cycles
+  const appRef = useRef<Application | null>(null);
+  const viewportRef = useRef<Viewport | null>(null);
+  const initializedRef = useRef(false);
+
+  // Graphics maps — keyed by "q,r"
+  const terrainGfxMap = useRef<Map<string, Graphics>>(new Map());
+  const overlayGfxMap = useRef<Map<string, Graphics>>(new Map());
+  const settlementGfxMap = useRef<Map<string, Graphics>>(new Map());
+  const locationGfxMap = useRef<Map<string, Graphics>>(new Map());
+
+  // Board geometry (computed once on mount)
+  const worldInfoRef = useRef<{
+    worldWidth: number;
+    worldHeight: number;
+    gridOffset: number;
+  } | null>(null);
+
+  // Hover state
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+
+  // Scale state for zoom badge
+  const [zoomScale, setZoomScale] = useState(1.0);
+
+  // InvalidFlash key with auto-clear
+  const [invalidFlashKey, setInvalidFlashKey] = useState<string | null>(null);
+  const invalidFlashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // RecentlyPlaced tracking
+  const [recentlyPlacedKey, setRecentlyPlacedKey] = useState<string | null>(null);
+  const recentlyPlacedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevSettlementKeysRef = useRef<Set<string>>(new Set());
+
+  // ─── Stable callbacks to avoid stale-closure issues in Pixi event handlers
+  // We store latest prop values in refs so the one-time Pixi event registration
+  // always reads current values without needing to re-attach handlers.
+  const boardRef = useRef(board);
+  const validPlacementsRef = useRef(validPlacements);
+  const onCellClickRef = useRef(onCellClick);
+  const onInvalidClickRef = useRef(onInvalidClick);
+  const onCellSelectRef = useRef(onCellSelect);
+
+  useEffect(() => { boardRef.current = board; }, [board]);
+  useEffect(() => { validPlacementsRef.current = validPlacements; }, [validPlacements]);
+  useEffect(() => { onCellClickRef.current = onCellClick; }, [onCellClick]);
+  useEffect(() => { onInvalidClickRef.current = onInvalidClick; }, [onInvalidClick]);
+  useEffect(() => { onCellSelectRef.current = onCellSelect; }, [onCellSelect]);
+
+  // ─── World geometry helper ────────────────────────────────────────────────
+  const computeWorldInfo = useCallback((b: Board) => {
+    const padding = HEX_SIZE * 2;
+    const maxX = HEX_SIZE * Math.sqrt(3) * ((b.width - 1) + 0.5 * (b.height - 1));
+    const maxY = HEX_SIZE * 1.5 * (b.height - 1);
+    const worldWidth = maxX + HEX_SIZE * 2 + padding * 2;
+    const worldHeight = maxY + HEX_SIZE * 2 + padding * 2;
+    const gridOffset = padding + HEX_SIZE;
+    return { worldWidth, worldHeight, gridOffset };
+  }, []);
+
+  // ─── World-point → hex coord (used in pointer events) ────────────────────
+  const worldPointToHex = useCallback(
+    (worldX: number, worldY: number, gridOffset: number): AxialCoord | null => {
+      const coord = pixelToAxial(
+        { x: worldX - gridOffset, y: worldY - gridOffset },
+        HEX_SIZE,
+      );
+      return boardRef.current.getCell(coord) ? coord : null;
+    },
+    [],
+  );
+
+  // ─── Build initial Pixi scene ─────────────────────────────────────────────
+  const buildScene = useCallback(
+    (viewport: Viewport, b: Board, gridOffset: number) => {
+      const hexContainer = new Container();
+      // Translate by gridOffset so hex (0,0) is not at the canvas corner
+      hexContainer.position.set(gridOffset, gridOffset);
+      viewport.addChild(hexContainer);
+
+      const cells = b.getAllCells();
+      for (const cell of cells) {
+        const key = hexToKey(cell.coord);
+
+        // Terrain layer
+        const tg = new Graphics();
+        const terrainCss = getTerrainColor(cell.terrain);
+        const terrainPx = cssColorToPixi(terrainCss);
+        drawHex(tg, cell.coord, terrainPx, 1.0, 0x000000, 0.3);
+        hexContainer.addChild(tg);
+        terrainGfxMap.current.set(key, tg);
+
+        // Location marker layer (static, drawn once)
+        if (cell.location !== undefined) {
+          const lg = new Graphics();
+          if (cell.location === Location.Castle) {
+            drawCastleMarker(lg, cell.coord);
+          } else {
+            const locColor = LOCATION_COLORS[cell.location] ?? 0xaaaaaa;
+            drawLocationDot(lg, cell.coord, locColor);
+          }
+          hexContainer.addChild(lg);
+          locationGfxMap.current.set(key, lg);
+        }
+
+        // Overlay layer (valid/hover/invalid/selected — updated dynamically)
+        const ov = new Graphics();
+        hexContainer.addChild(ov);
+        overlayGfxMap.current.set(key, ov);
+
+        // Settlement marker layer
+        const sm = new Graphics();
+        hexContainer.addChild(sm);
+        settlementGfxMap.current.set(key, sm);
+      }
+    },
+    [],
+  );
+
+  // ─── Update overlays + settlements (called on prop changes) ──────────────
+  const updateScene = useCallback(
+    (
+      b: Board,
+      valids: AxialCoord[],
+      hovKey: string | null,
+      sel: AxialCoord | null,
+      invalidKey: string | null,
+      recentKey: string | null,
+      pls: Player[],
+    ) => {
+      const validSet = new Set(valids.map(hexToKey));
+
+      for (const cell of b.getAllCells()) {
+        const key = hexToKey(cell.coord);
+
+        // ── Overlay ──────────────────────────────────────────────────────
+        const ov = overlayGfxMap.current.get(key);
+        if (ov) {
+          ov.clear();
+          if (invalidKey === key) {
+            // Red flash
+            drawHex(ov, cell.coord, 0xff0000, 0.45);
+          } else if (validSet.has(key)) {
+            if (hovKey === key) {
+              // Hovered valid: bright amber border + light fill
+              drawHex(ov, cell.coord, 0xffcc00, 0.22);
+              drawHexBorder(ov, cell.coord, 0xffcc00, 3);
+            } else {
+              // Valid placement: soft lime overlay
+              drawHex(ov, cell.coord, 0x80ff40, 0.18);
+              drawHexBorder(ov, cell.coord, 0x66dd22, 1.5, 0.7);
+            }
+          } else if (sel && sel.q === cell.coord.q && sel.r === cell.coord.r) {
+            // Selected (non-valid) — subtle highlight
+            drawHexBorder(ov, cell.coord, 0xffa500, 2.5, 0.9);
+          } else if (hovKey === key) {
+            // Hovered non-valid: faint white glow border
+            drawHexBorder(ov, cell.coord, 0xffffff, 2, 0.35);
+          }
+
+          // recentlyPlaced pop-in: bright white flash
+          if (recentKey === key) {
+            drawHex(ov, cell.coord, 0xffffff, 0.35);
+          }
+        }
+
+        // ── Settlement ────────────────────────────────────────────────────
+        const sm = settlementGfxMap.current.get(key);
+        if (sm) {
+          if (cell.settlement !== undefined) {
+            const player = pls.find(p => p.id === cell.settlement);
+            if (player?.color) {
+              drawSettlementCircle(sm, cell.coord, cssColorToPixi(player.color));
+            }
+          } else {
+            sm.clear();
+          }
+        }
+      }
+    },
+    [],
+  );
+
+  // ─── Pixi initialisation (runs once on mount) ─────────────────────────────
+  useEffect(() => {
+    if (initializedRef.current) return;
+    if (!canvasRef.current || !containerRef.current) return;
+    initializedRef.current = true;
+
+    const app = new Application();
+    appRef.current = app;
+
+    const worldInfo = computeWorldInfo(board);
+    worldInfoRef.current = worldInfo;
+    const { worldWidth, worldHeight, gridOffset } = worldInfo;
+
+    const containerEl = containerRef.current;
+
+    // async init — React useEffect cannot be async, use IIFE
+    (async () => {
+      // Guard: React StrictMode may have already cleaned up by the time init resolves
+      if (!initializedRef.current) return;
+
+      await app.init({
+        canvas: canvasRef.current!,
+        resizeTo: containerEl,
+        background: 0x1a1a2e,
+        antialias: true,
+        autoDensity: true,
+        resolution: window.devicePixelRatio || 1,
+      });
+
+      if (!initializedRef.current) {
+        app.destroy(true, { children: true, texture: true });
+        return;
+      }
+
+      // Viewport
+      const vp = new Viewport({
+        screenWidth: containerEl.clientWidth,
+        screenHeight: containerEl.clientHeight,
+        worldWidth,
+        worldHeight,
+        events: app.renderer.events,
+        // threshold: minimum pixel movement before drag begins
+        // Prevents click-swallowed-by-pan (root cause of R30 bug)
+        threshold: 5,
+      });
+      viewportRef.current = vp;
+
+      app.stage.addChild(vp);
+
+      vp
+        .drag({ pressDrag: true, mouseButtons: 'all' })
+        .pinch()
+        .wheel({ smooth: 5 })
+        .decelerate({ friction: 0.94 })
+        .clamp({ direction: 'all', underflow: 'center' })
+        .clampZoom({ minScale: 0.25, maxScale: 5.0 });
+
+      // Initial centre + fit
+      const scaleX = containerEl.clientWidth / worldWidth;
+      const scaleY = containerEl.clientHeight / worldHeight;
+      const initScale = Math.min(scaleX, scaleY) * 0.92;
+      vp.setZoom(initScale, true);
+      vp.moveCenter(worldWidth / 2, worldHeight / 2);
+      setZoomScale(initScale);
+
+      // Track zoom for badge
+      vp.on('zoomed', () => {
+        setZoomScale(vp.scaled);
+      });
+      vp.on('moved', () => {
+        setZoomScale(vp.scaled);
+      });
+
+      // Build scene
+      buildScene(vp, boardRef.current, gridOffset);
+
+      // Initial overlay render
+      updateScene(
+        boardRef.current,
+        validPlacementsRef.current,
+        null,
+        null,
+        null,
+        null,
+        players,
+      );
+
+      // ── Pointer events ──────────────────────────────────────────────────
+      vp.on('pointermove', (e) => {
+        const { x, y } = e.getLocalPosition(vp);
+        const coord = worldPointToHex(x, y, gridOffset);
+        if (coord) {
+          const k = hexToKey(coord);
+          setHoveredKey(k);
+          onCellSelectRef.current(coord);
+        } else {
+          setHoveredKey(null);
+          onCellSelectRef.current(null);
+        }
+      });
+
+      vp.on('pointertap', (e) => {
+        const { x, y } = e.getLocalPosition(vp);
+        const coord = worldPointToHex(x, y, gridOffset);
+        if (!coord) return;
+        const validSet = new Set(validPlacementsRef.current.map(hexToKey));
+        if (validSet.has(hexToKey(coord))) {
+          onCellClickRef.current(coord);
+        } else {
+          onInvalidClickRef.current?.(coord);
+        }
+      });
+
+      vp.on('pointerleave', () => {
+        setHoveredKey(null);
+        onCellSelectRef.current(null);
+      });
+    })();
+
+    // Cleanup
+    return () => {
+      initializedRef.current = false;
+      if (appRef.current) {
+        try {
+          appRef.current.destroy(true, { children: true, texture: true });
+        } catch {
+          // suppress destroy errors during unmount
+        }
+        appRef.current = null;
+      }
+      viewportRef.current = null;
+      terrainGfxMap.current.clear();
+      overlayGfxMap.current.clear();
+      settlementGfxMap.current.clear();
+      locationGfxMap.current.clear();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Only runs on mount
+
+  // ─── invalidClickKey → flash state ────────────────────────────────────────
+  useEffect(() => {
+    if (!invalidClickKey) return;
+    if (invalidFlashTimerRef.current) clearTimeout(invalidFlashTimerRef.current);
+    setInvalidFlashKey(invalidClickKey);
+    invalidFlashTimerRef.current = setTimeout(() => setInvalidFlashKey(null), 400);
+    return () => {
+      if (invalidFlashTimerRef.current) clearTimeout(invalidFlashTimerRef.current);
+    };
+  }, [invalidClickKey]);
+
+  // ─── recentlyPlaced detection ─────────────────────────────────────────────
+  useEffect(() => {
+    const cells = board.getAllCells();
+    const currentKeys = new Set<string>();
+    for (const cell of cells) {
+      if (cell.settlement !== undefined) {
+        currentKeys.add(hexToKey(cell.coord));
+      }
+    }
+    let newKey: string | null = null;
+    for (const key of currentKeys) {
+      if (!prevSettlementKeysRef.current.has(key)) {
+        newKey = key;
+        break;
+      }
+    }
+    prevSettlementKeysRef.current = currentKeys;
+
+    if (newKey) {
+      if (recentlyPlacedTimerRef.current) clearTimeout(recentlyPlacedTimerRef.current);
+      setRecentlyPlacedKey(newKey);
+      recentlyPlacedTimerRef.current = setTimeout(() => setRecentlyPlacedKey(null), 350);
+    }
+    return () => {
+      if (recentlyPlacedTimerRef.current) clearTimeout(recentlyPlacedTimerRef.current);
+    };
+  }, [board]);
+
+  // ─── Re-render overlays when relevant props change ────────────────────────
+  useEffect(() => {
+    if (!initializedRef.current) return;
+    updateScene(
+      board,
+      validPlacements,
+      hoveredKey,
+      selectedCell,
+      invalidFlashKey,
+      recentlyPlacedKey,
+      players,
+    );
+  }, [
+    board,
+    validPlacements,
+    hoveredKey,
+    selectedCell,
+    invalidFlashKey,
+    recentlyPlacedKey,
+    players,
+    updateScene,
+  ]);
+
+  // ─── Zoom reset handler ───────────────────────────────────────────────────
+  const handleResetZoom = useCallback(() => {
+    const vp = viewportRef.current;
+    const wInfo = worldInfoRef.current;
+    const containerEl = containerRef.current;
+    if (!vp || !wInfo || !containerEl) return;
+    const scaleX = containerEl.clientWidth / wInfo.worldWidth;
+    const scaleY = containerEl.clientHeight / wInfo.worldHeight;
+    const fitScale = Math.min(scaleX, scaleY) * 0.92;
+    vp.animate({
+      position: { x: wInfo.worldWidth / 2, y: wInfo.worldHeight / 2 },
+      scale: fitScale,
+      time: 300,
+      ease: 'easeInOutSine',
+    });
+  }, []);
+
+  // ─── Render ───────────────────────────────────────────────────────────────
+  return (
+    <div
+      ref={containerRef}
+      className="w-full h-full relative overflow-hidden select-none"
+      style={{
+        background: 'var(--board-inner-bg)',
+        touchAction: 'none',
+        cursor: 'grab',
+      }}
+    >
+      <canvas
+        ref={canvasRef}
+        style={{ display: 'block', width: '100%', height: '100%' }}
+        // canvas has no DOM focus ring — no tabIndex, no outline
+      />
+
+      {/* Zoom reset button (React DOM overlay) */}
+      <button
+        className="absolute top-2 right-2 z-10 rounded-full w-9 h-9 text-sm font-bold shadow flex items-center justify-center"
+        style={{ background: 'oklch(0.98 0.01 85 / 0.85)', border: '1px solid var(--card-border)' }}
+        onMouseEnter={e => (e.currentTarget.style.background = 'var(--color-surface)')}
+        onMouseLeave={e => (e.currentTarget.style.background = 'oklch(0.98 0.01 85 / 0.85)')}
+        onClick={handleResetZoom}
+        title={t('board.resetZoomTitle')}
+        aria-label={t('board.resetZoomAria')}
+      >
+        ⌖
+      </button>
+
+      {/* Zoom level badge */}
+      <div
+        className="absolute bottom-2 right-2 z-10 text-xs rounded px-2 py-0.5 pointer-events-none"
+        style={{ background: 'oklch(0.98 0.01 85 / 0.75)', color: 'var(--color-stone-500)' }}
+      >
+        {Math.round(zoomScale * 100)}%
+      </div>
+    </div>
+  );
+};
+
+PixiBoard.displayName = 'PixiBoard';

--- a/src/components/Board/pixiHexUtils.ts
+++ b/src/components/Board/pixiHexUtils.ts
@@ -1,0 +1,129 @@
+/**
+ * Pixi v8 drawing utilities for hex grid rendering.
+ * Wraps core/hex.ts functions — no logic duplication.
+ */
+import { Graphics } from 'pixi.js';
+import { axialToPixel, hexCorners, HEX_SIZE } from '../../core/hex';
+import type { AxialCoord } from '../../core/hex';
+
+/**
+ * CSS hex color string (#rrggbb or #rgb) to Pixi number (0xRRGGBB).
+ */
+export function cssColorToPixi(css: string): number {
+  const hex = css.replace('#', '');
+  if (hex.length === 3) {
+    // Expand short form
+    const r = parseInt(hex[0] + hex[0], 16);
+    const g = parseInt(hex[1] + hex[1], 16);
+    const b = parseInt(hex[2] + hex[2], 16);
+    return (r << 16) | (g << 8) | b;
+  }
+  return parseInt(hex.length === 6 ? hex : hex.slice(0, 6), 16);
+}
+
+/**
+ * Draw a filled hex polygon on a Graphics object using Pixi v8 API.
+ * Uses moveTo/lineTo to avoid poly() TypeScript overload ambiguity.
+ *
+ * @param g           Graphics object (will be cleared first)
+ * @param coord       Axial coordinate
+ * @param fillColor   Fill color (0xRRGGBB)
+ * @param fillAlpha   Fill alpha (0–1)
+ * @param strokeColor Stroke color (0xRRGGBB), undefined = no stroke
+ * @param strokeWidth Stroke pixel width
+ */
+export function drawHex(
+  g: Graphics,
+  coord: AxialCoord,
+  fillColor: number,
+  fillAlpha: number,
+  strokeColor?: number,
+  strokeWidth?: number,
+): void {
+  const corners = hexCorners(coord, HEX_SIZE);
+  g.clear();
+
+  if (strokeColor !== undefined && strokeWidth && strokeWidth > 0) {
+    g.setStrokeStyle({ width: strokeWidth, color: strokeColor, alpha: 1 });
+  }
+
+  g.moveTo(corners[0].x, corners[0].y);
+  for (let i = 1; i < 6; i++) {
+    g.lineTo(corners[i].x, corners[i].y);
+  }
+  g.closePath();
+  g.fill({ color: fillColor, alpha: fillAlpha });
+
+  if (strokeColor !== undefined && strokeWidth && strokeWidth > 0) {
+    g.stroke();
+  }
+}
+
+/**
+ * Draw only the hex border (no fill) — used for hover/selected overlays.
+ */
+export function drawHexBorder(
+  g: Graphics,
+  coord: AxialCoord,
+  strokeColor: number,
+  strokeWidth: number,
+  strokeAlpha = 1,
+): void {
+  const corners = hexCorners(coord, HEX_SIZE);
+  g.clear();
+  g.setStrokeStyle({ width: strokeWidth, color: strokeColor, alpha: strokeAlpha });
+  g.moveTo(corners[0].x, corners[0].y);
+  for (let i = 1; i < 6; i++) {
+    g.lineTo(corners[i].x, corners[i].y);
+  }
+  g.closePath();
+  g.stroke();
+}
+
+/**
+ * Draw a filled circle (settlement marker) centred on the hex.
+ */
+export function drawSettlementCircle(
+  g: Graphics,
+  coord: AxialCoord,
+  color: number,
+  radius = HEX_SIZE * 0.35,
+): void {
+  const center = axialToPixel(coord, HEX_SIZE);
+  g.clear();
+  g.circle(center.x, center.y, radius);
+  g.fill({ color, alpha: 1 });
+  // White ring outline for contrast
+  g.circle(center.x, center.y, radius);
+  g.setStrokeStyle({ width: 2, color: 0xffffff, alpha: 0.8 });
+  g.stroke();
+}
+
+/**
+ * Draw a small text-like castle indicator (⬡ shape with fill + "C" not needed in Phase 1).
+ * Uses a filled diamond / rectangle above centre for simplicity.
+ */
+export function drawCastleMarker(g: Graphics, coord: AxialCoord): void {
+  const center = axialToPixel(coord, HEX_SIZE);
+  const s = HEX_SIZE * 0.22;
+  g.clear();
+  // Simple rotated square
+  g.moveTo(center.x, center.y - s * 1.4);
+  g.lineTo(center.x + s, center.y - s * 0.4);
+  g.lineTo(center.x, center.y + s * 0.6);
+  g.lineTo(center.x - s, center.y - s * 0.4);
+  g.closePath();
+  g.fill({ color: 0xffd700, alpha: 0.9 });
+  g.setStrokeStyle({ width: 1.5, color: 0xaa8800, alpha: 1 });
+  g.stroke();
+}
+
+/**
+ * Draw a small location indicator dot (non-castle special locations).
+ */
+export function drawLocationDot(g: Graphics, coord: AxialCoord, color: number): void {
+  const center = axialToPixel(coord, HEX_SIZE);
+  g.clear();
+  g.circle(center.x, center.y - HEX_SIZE * 0.25, HEX_SIZE * 0.18);
+  g.fill({ color, alpha: 0.85 });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,13 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks(id) {
+          // vendor-pixi: WebGL 渲染引擎（大體積，獨立 chunk，棋盤畫面才載入）
+          if (
+            id.includes('node_modules/pixi.js/') ||
+            id.includes('node_modules/pixi-viewport/')
+          ) {
+            return 'vendor-pixi'
+          }
           // vendor-react: react core 三件套（緊耦合，務必同組避免拆散導致 undefined export 白屏）
           if (
             id.includes('node_modules/react-dom/') ||


### PR DESCRIPTION
## R35 Phase 1：PixiBoard（老闆戰略決策）

遊戲區棋盤反覆出互動 bug（點擊被吞、focus 矩形框、縮放跳動）因手刻 SVG 重造輪子。老闆指示改用正規 2D 引擎 **PixiJS + pixi-viewport**。

### 內容（Phase 1，根治 bug；R24 精緻美術留 Phase 2）
- 新 `PixiBoard.tsx`(512)+`pixiHexUtils.ts`(129)：PixiJS v8（WebGL）+ pixi-viewport
- pan/zoom/pinch/wheel/clamp/**拖動門檻(threshold:5)**/點擊命中全交給 pixi-viewport
- 功能性渲染：地形底色+地點/聚落標記+valid/hover/invalid 高亮（hex 數學復用 core/hex.ts）
- vite vendor-pixi chunk(145KB gzip 獨立，主 chunk 反降至 63KB gzip)
- App.tsx 遊戲畫面 HexGrid→PixiBoard；MapEditor 留舊 SVG(Phase 2)
- **遊戲邏輯零改動**(只讀 board/validPlacements + 呼叫既有 callback)

### CEO 親測（npm run build + Playwright 真實滑鼠）— 互動 bug 根治確認
- ✅ 真實點擊放置成功(沙漠 3→2)
- ✅ **微移 4px 點擊仍放置**(threshold:5，根治「點了房子沒上」)
- ✅ pan(大拖曳)不誤放置
- ✅ **無藍色 focus 矩形框**(canvas 天生無 DOM focus ring，根治老闆藍框 bug)
- ✅ **點擊不改 zoom**(pixi-viewport zoom 只走 wheel/pinch，根治老闆「點一下變巨大」)
- ✅ 單 canvas(StrictMode guard)、unmount 無洩漏
- ✅ npm run build(含 tsc -b)exit 0 / vitest 411 / eye 0 / 無 game logic 改動
- 安全雙審：主流庫+純渲染互動層，不觸發

🤖 Generated with [Claude Code](https://claude.com/claude-code)
