### PR TITLE
feat(r36-2a): PixiJS art migration - terrain gradient + grain + wood background

### DIFF
--- a/src/components/Board/PixiBoard.tsx
+++ b/src/components/Board/PixiBoard.tsx
@@ -11,7 +11,7 @@
  */
 
 import React, { useEffect, useRef, useState, useCallback } from 'react';
-import { Application, Graphics, Container } from 'pixi.js';
+import { Application, Graphics, Container, NoiseFilter } from 'pixi.js';
 import { Viewport } from 'pixi-viewport';
 import type { Board } from '../../core/board';
 import type { AxialCoord } from '../../core/hex';
@@ -23,10 +23,13 @@ import {
   cssColorToPixi,
   drawHex,
   drawHexBorder,
+  drawHexGradient,
+  drawHexLightOverlay,
   drawSettlementCircle,
   drawCastleMarker,
   drawLocationDot,
 } from './pixiHexUtils';
+import { TERRAIN_GRADIENTS, getTerrainVariant } from './terrainArt';
 import { useTranslation } from 'react-i18next';
 
 // ─── Location indicator colours (functional, not R24 art) ───────────────────
@@ -75,6 +78,7 @@ export const PixiBoard: React.FC<PixiBoardProps> = ({
 
   // Graphics maps — keyed by "q,r"
   const terrainGfxMap = useRef<Map<string, Graphics>>(new Map());
+  const lightOverlayGfxMap = useRef<Map<string, Graphics>>(new Map());
   const overlayGfxMap = useRef<Map<string, Graphics>>(new Map());
   const settlementGfxMap = useRef<Map<string, Graphics>>(new Map());
   const locationGfxMap = useRef<Map<string, Graphics>>(new Map());
@@ -147,19 +151,44 @@ export const PixiBoard: React.FC<PixiBoardProps> = ({
       hexContainer.position.set(gridOffset, gridOffset);
       viewport.addChild(hexContainer);
 
+      // R36 Phase 2a: terrainLayer sub-container holds terrain + light overlay.
+      // NoiseFilter is applied to this layer ONLY (not hexContainer),
+      // so grain does not affect location markers / overlay / settlements.
+      const terrainLayer = new Container();
+      hexContainer.addChild(terrainLayer);
+
+      // Grain filter: O(1), applied once to terrainLayer
+      const noiseFilter = new NoiseFilter({ noise: 0.04, seed: 42 });
+      terrainLayer.filters = [noiseFilter];
+
       const cells = b.getAllCells();
       for (const cell of cells) {
         const key = hexToKey(cell.coord);
 
-        // Terrain layer
+        // Terrain gradient layer (R36 Phase 2a: replaces flat colour)
         const tg = new Graphics();
-        const terrainCss = getTerrainColor(cell.terrain);
-        const terrainPx = cssColorToPixi(terrainCss);
-        drawHex(tg, cell.coord, terrainPx, 1.0, 0x000000, 0.3);
-        hexContainer.addChild(tg);
+        const variant = getTerrainVariant(cell.coord.q, cell.coord.r);
+        const terrainName = cell.terrain as string;
+        const gradKey = `${terrainName}-${variant}`;
+        const grad = TERRAIN_GRADIENTS[gradKey];
+        if (grad) {
+          drawHexGradient(tg, cell.coord, grad);
+        } else {
+          // Fallback to flat colour for unknown terrain types
+          const terrainCss = getTerrainColor(cell.terrain);
+          const terrainPx = cssColorToPixi(terrainCss);
+          drawHex(tg, cell.coord, terrainPx, 1.0, 0x000000, 0.3);
+        }
+        terrainLayer.addChild(tg);
         terrainGfxMap.current.set(key, tg);
 
-        // Location marker layer (static, drawn once)
+        // Light overlay layer (R36 Phase 2a: directional light above terrain)
+        const log = new Graphics();
+        drawHexLightOverlay(log, cell.coord);
+        terrainLayer.addChild(log);
+        lightOverlayGfxMap.current.set(key, log);
+
+        // Location marker layer (static, drawn once) — outside terrainLayer (no grain)
         if (cell.location !== undefined) {
           const lg = new Graphics();
           if (cell.location === Location.Castle) {
@@ -172,12 +201,12 @@ export const PixiBoard: React.FC<PixiBoardProps> = ({
           locationGfxMap.current.set(key, lg);
         }
 
-        // Overlay layer (valid/hover/invalid/selected — updated dynamically)
+        // Overlay layer (valid/hover/invalid/selected — updated dynamically) — outside terrainLayer
         const ov = new Graphics();
         hexContainer.addChild(ov);
         overlayGfxMap.current.set(key, ov);
 
-        // Settlement marker layer
+        // Settlement marker layer — outside terrainLayer
         const sm = new Graphics();
         hexContainer.addChild(sm);
         settlementGfxMap.current.set(key, sm);
@@ -273,7 +302,7 @@ export const PixiBoard: React.FC<PixiBoardProps> = ({
       await app.init({
         canvas: canvasRef.current!,
         resizeTo: containerEl,
-        background: 0x1a1a2e,
+        background: 0x2C1A0E, // R36 Phase 2a: 深木棕（取代深藍黑 0x1a1a2e）
         antialias: true,
         autoDensity: true,
         resolution: window.devicePixelRatio || 1,
@@ -382,6 +411,7 @@ export const PixiBoard: React.FC<PixiBoardProps> = ({
       }
       viewportRef.current = null;
       terrainGfxMap.current.clear();
+      lightOverlayGfxMap.current.clear();
       overlayGfxMap.current.clear();
       settlementGfxMap.current.clear();
       locationGfxMap.current.clear();
@@ -474,7 +504,10 @@ export const PixiBoard: React.FC<PixiBoardProps> = ({
       ref={containerRef}
       className="w-full h-full relative overflow-hidden select-none"
       style={{
-        background: 'var(--board-inner-bg)',
+        // R36 Phase 2a: 深木棕背景 + 木桌框 CSS MVP（羊皮紙感 border + shadow）
+        background: '#2C1A0E',
+        border: '6px solid #5C3A1E',
+        boxShadow: 'inset 0 0 24px rgba(0,0,0,0.5), 0 4px 16px rgba(0,0,0,0.4)',
         touchAction: 'none',
         cursor: 'grab',
       }}

--- a/src/components/Board/pixiHexUtils.ts
+++ b/src/components/Board/pixiHexUtils.ts
@@ -1,10 +1,16 @@
 /**
  * Pixi v8 drawing utilities for hex grid rendering.
  * Wraps core/hex.ts functions — no logic duplication.
+ *
+ * R36 Phase 2a additions:
+ *   - drawHexGradient(): terrain gradient fill (FillGradient, local space)
+ *   - drawHexLightOverlay(): directional light overlay (3-stop gradient)
  */
-import { Graphics } from 'pixi.js';
+import { Graphics, FillGradient } from 'pixi.js';
 import { axialToPixel, hexCorners, HEX_SIZE } from '../../core/hex';
 import type { AxialCoord } from '../../core/hex';
+import type { TerrainGradient } from './terrainArt';
+import { LIGHT_OVERLAY_STOPS } from './terrainArt';
 
 /**
  * CSS hex color string (#rrggbb or #rgb) to Pixi number (0xRRGGBB).
@@ -126,4 +132,92 @@ export function drawLocationDot(g: Graphics, coord: AxialCoord, color: number): 
   g.clear();
   g.circle(center.x, center.y - HEX_SIZE * 0.25, HEX_SIZE * 0.18);
   g.fill({ color, alpha: 0.85 });
+}
+
+// ─── R36 Phase 2a: Gradient drawing utilities ────────────────────────────────
+
+/**
+ * Draw a hex polygon filled with a linear gradient (R36 Phase 2a).
+ *
+ * Uses Pixi v8 FillGradient with textureSpace:'local' so coordinates 0-1
+ * map to the shape's bounding box — exactly matching SVG objectBoundingBox.
+ *
+ * Direction: top-left → bottom-right, matching TerrainDefs.tsx
+ * linearGradient x1="0.15" y1="0" x2="0.85" y2="1"
+ *
+ * @param g       Graphics object (will be cleared first)
+ * @param coord   Axial coordinate
+ * @param grad    Gradient definition with stop0 and stop1 colors
+ */
+export function drawHexGradient(
+  g: Graphics,
+  coord: AxialCoord,
+  grad: TerrainGradient,
+): void {
+  const corners = hexCorners(coord, HEX_SIZE);
+  g.clear();
+
+  // FillGradient v8 new-style API: textureSpace 'local' = coords 0-1 relative to shape bounds
+  // Matches SVG objectBoundingBox: x1=0.15 y1=0 x2=0.85 y2=1
+  const gradient = new FillGradient({
+    type: 'linear',
+    start: { x: 0.15, y: 0 },
+    end:   { x: 0.85, y: 1 },
+    textureSpace: 'local',
+    colorStops: [
+      { offset: 0, color: grad.stop0 },
+      { offset: 1, color: grad.stop1 },
+    ],
+  });
+
+  // Draw hex path with gradient fill + thin dark stroke for cell separation
+  g.setStrokeStyle({ width: 0.3, color: 0x000000, alpha: 0.3 });
+  g.moveTo(corners[0].x, corners[0].y);
+  for (let i = 1; i < 6; i++) {
+    g.lineTo(corners[i].x, corners[i].y);
+  }
+  g.closePath();
+  g.fill({ fill: gradient });
+  g.stroke();
+}
+
+/**
+ * Draw a directional light overlay on a hex cell (R36 Phase 2a).
+ *
+ * Replicates TerrainDefs.tsx `#light-overlay`:
+ *   top-left 18% white → mid 4% white → bottom-right 8% black
+ *
+ * Uses rgba string ColorSource to encode per-stop alpha in FillGradient.
+ * Layered above terrain, below location/overlay/settlement.
+ *
+ * @param g     Graphics object (will be cleared first)
+ * @param coord Axial coordinate
+ */
+export function drawHexLightOverlay(
+  g: Graphics,
+  coord: AxialCoord,
+): void {
+  const corners = hexCorners(coord, HEX_SIZE);
+  g.clear();
+
+  // 3-stop gradient matching TerrainDefs.tsx #light-overlay
+  // ColorSource accepts rgba string for per-stop alpha
+  const gradient = new FillGradient({
+    type: 'linear',
+    start: { x: 0, y: 0 },
+    end:   { x: 1, y: 1 },
+    textureSpace: 'local',
+    colorStops: [
+      { offset: LIGHT_OVERLAY_STOPS[0].offset, color: `rgba(255,255,255,${LIGHT_OVERLAY_STOPS[0].alpha})` },
+      { offset: LIGHT_OVERLAY_STOPS[1].offset, color: `rgba(255,255,255,${LIGHT_OVERLAY_STOPS[1].alpha})` },
+      { offset: LIGHT_OVERLAY_STOPS[2].offset, color: `rgba(0,0,0,${LIGHT_OVERLAY_STOPS[2].alpha})` },
+    ],
+  });
+
+  g.moveTo(corners[0].x, corners[0].y);
+  for (let i = 1; i < 6; i++) {
+    g.lineTo(corners[i].x, corners[i].y);
+  }
+  g.closePath();
+  g.fill({ fill: gradient });
 }

--- a/src/components/Board/terrainArt.ts
+++ b/src/components/Board/terrainArt.ts
@@ -1,0 +1,77 @@
+/**
+ * terrainArt.ts — R36 Phase 2a
+ *
+ * 地形漸層色值表（直接從 TerrainDefs.tsx 的 21 個 linearGradient 抄錄）
+ * 7 地形 × A/B/C 明度變體，方向對應 x1=0.15 y1=0 x2=0.85 y2=1 (objectBoundingBox)
+ *
+ * 供 pixiHexUtils.ts 的 drawHexGradient() 使用。
+ */
+
+/** 單一漸層定義：stop 0% 和 stop 100% 的 Pixi hex 色值 */
+export interface TerrainGradient {
+  stop0: number; // start color (top-left)
+  stop1: number; // end color (bottom-right)
+}
+
+/**
+ * 21 組地形漸層色值表（TerrainDefs.tsx linearGradient 直接抄錄）
+ * key: "{TerrainType}-{variant}"  e.g. "Grass-a"
+ */
+export const TERRAIN_GRADIENTS: Record<string, TerrainGradient> = {
+  // 草原 Grass（基底 #7ABF5E）
+  'Grass-a': { stop0: 0x92D470, stop1: 0x6AAF4E },
+  'Grass-b': { stop0: 0x7ABF5E, stop1: 0x5EAF44 },
+  'Grass-c': { stop0: 0x68A84E, stop1: 0x509838 },
+
+  // 森林 Forest（基底 #2D7A2D）
+  'Forest-a': { stop0: 0x357A35, stop1: 0x205220 },
+  'Forest-b': { stop0: 0x2D7A2D, stop1: 0x1A5A1A },
+  'Forest-c': { stop0: 0x226222, stop1: 0x124512 },
+
+  // 沙漠 Desert（基底 #E8A84A）
+  'Desert-a': { stop0: 0xF0B85A, stop1: 0xD09040 },
+  'Desert-b': { stop0: 0xE8A84A, stop1: 0xC89038 },
+  'Desert-c': { stop0: 0xD89838, stop1: 0xB87828 },
+
+  // 花田 Flower（基底 #F06080）
+  'Flower-a': { stop0: 0xF87898, stop1: 0xE04870 },
+  'Flower-b': { stop0: 0xF06080, stop1: 0xD84868 },
+  'Flower-c': { stop0: 0xD85070, stop1: 0xC03860 },
+
+  // 峽谷 Canyon（基底 #C05020）
+  'Canyon-a': { stop0: 0xD06030, stop1: 0xA84018 },
+  'Canyon-b': { stop0: 0xC05020, stop1: 0x9C3C14 },
+  'Canyon-c': { stop0: 0xA84418, stop1: 0x8A300C },
+
+  // 水域 Water（基底 #3A74B0）
+  'Water-a': { stop0: 0x4A84C0, stop1: 0x2C64A0 },
+  'Water-b': { stop0: 0x3A74B0, stop1: 0x2A5C98 },
+  'Water-c': { stop0: 0x2E64A0, stop1: 0x1E4C88 },
+
+  // 山脈 Mountain（基底 #888888）
+  'Mountain-a': { stop0: 0x9C9C9C, stop1: 0x787878 },
+  'Mountain-b': { stop0: 0x888888, stop1: 0x686868 },
+  'Mountain-c': { stop0: 0x787878, stop1: 0x585858 },
+};
+
+/**
+ * light-overlay 三個 stop 色值
+ * 來源：TerrainDefs.tsx `#light-overlay` linearGradient
+ *   stop 0%:   #FFFFFF opacity 0.18
+ *   stop 50%:  #FFFFFF opacity 0.04
+ *   stop 100%: #000000 opacity 0.08
+ */
+export const LIGHT_OVERLAY_STOPS = [
+  { offset: 0,    color: 0xffffff as number, alpha: 0.18 },
+  { offset: 0.5,  color: 0xffffff as number, alpha: 0.04 },
+  { offset: 1.0,  color: 0x000000 as number, alpha: 0.08 },
+] as const;
+
+/**
+ * 根據格座標 hash 決定 A/B/C 變體（同局固定，不亂跳）
+ * hash = Math.abs(q * 31 + r * 17) % 3
+ */
+export function getTerrainVariant(q: number, r: number): 'a' | 'b' | 'c' {
+  const idx = Math.abs(q * 31 + r * 17) % 3;
+  return (['a', 'b', 'c'] as const)[idx];
+}


### PR DESCRIPTION
## Summary

- **地形漸層**：21 組 FillGradient（7 地形 × A/B/C 變體），色值直接從 `TerrainDefs.tsx` linearGradient 抄錄，取代 R35 純色填充
- **方向光疊層**：`drawHexLightOverlay()` 複製 `#light-overlay` 三色 stop（白 18%→4%→黑 8%）
- **grain**：`NoiseFilter({ noise: 0.04, seed: 42 })` 只套 `terrainLayer` sub-container（CEO 修正 2：不蓋棋子/高亮/聚落）
- **深木背景**：App background `0x2C1A0E` + div CSS border/box-shadow 木桌框 MVP

## 改動檔案

| 檔案 | 說明 |
|------|------|
| `src/components/Board/terrainArt.ts` | **新增** — 21 組漸層色值表 + `getTerrainVariant()` hash |
| `src/components/Board/pixiHexUtils.ts` | 新增 `drawHexGradient()` + `drawHexLightOverlay()` |
| `src/components/Board/PixiBoard.tsx` | buildScene 改用 gradient；terrainLayer container；NoiseFilter；木棕背景 |

## CEO 2 點修正落實說明

**修正 1（FillGradient API 對版）**：
查 `node_modules/pixi.js/dist/pixi.js.d.ts` 確認 8.18.1 實際建構子簽名：
```ts
// 新式（推薦，positional 已 deprecated）
new FillGradient({ type: 'linear', start: {x, y}, end: {x, y},
  textureSpace: 'local', colorStops: [{offset, color}, ...] })
```
`textureSpace: 'local'` 表示座標 0-1 對應 shape bounding box，**完全對應 SVG objectBoundingBox**，不需換算世界座標。方向 `start: {x:0.15, y:0}` → `end: {x:0.85, y:1}` 直接映射 `x1="0.15" y1="0" x2="0.85" y2="1"`。

**修正 2（grain 只套地形層）**：
建立 `terrainLayer = new Container()`，裝所有 `terrainGfx` + `lightOverlayGfx`。`NoiseFilter` 套 `terrainLayer`，`hexContainer` 本身不套。location markers / overlay / settlements 加到 `hexContainer` 直接子層，不受 grain 影響。

## FillGradient 8.18.1 實際 API

```ts
import { FillGradient } from 'pixi.js';
new FillGradient({
  type: 'linear',
  start: { x: 0.15, y: 0 },
  end:   { x: 0.85, y: 1 },
  textureSpace: 'local',           // 0-1 = shape bounding box
  colorStops: [
    { offset: 0, color: 0x92D470 },
    { offset: 1, color: 0x6AAF4E },
  ],
});
```

light-overlay per-stop alpha 透過 rgba string ColorSource 實現：
```ts
colorStops: [
  { offset: 0,   color: 'rgba(255,255,255,0.18)' },
  { offset: 0.5, color: 'rgba(255,255,255,0.04)' },
  { offset: 1.0, color: 'rgba(0,0,0,0.08)' },
]
```

## grain 套哪層

`terrainLayer`（sub-container，只含 terrainGfx + lightOverlayGfx）  
**不套 hexContainer**（hexContainer 含 location/overlay/settlement，不受 grain 影響）

## 自驗結果

| 項目 | 結果 |
|------|------|
| `npm run build`（tsc -b + vite build） | 零錯誤零 warning（chunk size warning 為既有 vendor-pixi，非新增）|
| `npx vitest run` | 411/411 passed |

## 待 CEO 驗收

- docker compose build --no-cache --pull && up -d → http://localhost:8087
- 視覺確認：地形漸層（非純色）、A/B/C 明度差、grain 可見不喧賓奪主、深木棕背景
- 互動確認：hover / valid-placement / invalid-flash / pan / zoom 不退化

## Reviewer

建議：@dev-manager

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
