### PR TITLE
feat(r36-2c): PixiBoard 聚落升級為 2.5D 立體小房子 Sprite.tint

### DIFF
--- a/src/components/Board/PixiBoard.tsx
+++ b/src/components/Board/PixiBoard.tsx
@@ -305,10 +305,17 @@ export const PixiBoard: React.FC<PixiBoardProps> = ({
               sprite.width = HEX_SIZE * 0.9;
               sprite.height = HEX_SIZE * 0.95;
               sprite.tint = tint;
-              // 插入 hexContainer（從 settlementGfxMap 的 parent 拿參照）
+              // 插入 hexContainer 的 sm 錨點位置（非尾端），確保 overlay 高亮層仍在聚落之上、
+              // hover/valid/invalid 回饋不被小房子遮住（dev-manager #173 z-order 修正）。
+              // container 為 null 則跳過建立，避免孤兒 Sprite 洩漏（dev-manager #173 防呆）。
               const smGfx = settlementGfxMap.current.get(key);
-              smGfx?.parent?.addChild(sprite);
-              settlementSpriteMap.current.set(key, sprite);
+              const container = smGfx?.parent;
+              if (container) {
+                container.addChildAt(sprite, container.getChildIndex(smGfx));
+                settlementSpriteMap.current.set(key, sprite);
+              } else {
+                sprite.destroy();
+              }
             }
           }
         } else {

--- a/src/components/Board/PixiBoard.tsx
+++ b/src/components/Board/PixiBoard.tsx
@@ -24,7 +24,7 @@ import {
   drawHexBorder,
   drawHexGradient,
   drawHexLightOverlay,
-  drawSettlementCircle,
+  HOUSE_DATA_URL,
 } from './pixiHexUtils';
 import { TERRAIN_GRADIENTS, getTerrainVariant } from './terrainArt';
 import { MOTIF_DATA_URLS } from './motifTextures';
@@ -78,6 +78,11 @@ export const PixiBoard: React.FC<PixiBoardProps> = ({
   const pieceSpriteMap = useRef<Map<string, Sprite>>(new Map());
   // R36 Phase 2b-2: piece Texture map (for cleanup) — keyed by Location enum value
   const pieceTextureMapRef = useRef<Map<string, Texture>>(new Map());
+
+  // R36 Phase 2c: settlement Sprite map — keyed by "q,r" (dynamic, add/remove per placement)
+  const settlementSpriteMap = useRef<Map<string, Sprite>>(new Map());
+  // R36 Phase 2c: white-house texture (shared by all settlement Sprites)
+  const houseTextureRef = useRef<Texture | null>(null);
 
   // Board geometry (computed once on mount)
   const worldInfoRef = useRef<{
@@ -279,16 +284,38 @@ export const PixiBoard: React.FC<PixiBoardProps> = ({
           }
         }
 
-        // ── Settlement ────────────────────────────────────────────────────
-        const sm = settlementGfxMap.current.get(key);
-        if (sm) {
-          if (cell.settlement !== undefined) {
-            const player = pls.find(p => p.id === cell.settlement);
-            if (player?.color) {
-              drawSettlementCircle(sm, cell.coord, cssColorToPixi(player.color));
-            }
+        // ── Settlement (R36 Phase 2c: Sprite.tint 2.5D 小房子) ───────────
+        const existingSprite = settlementSpriteMap.current.get(key);
+
+        if (cell.settlement !== undefined) {
+          const player = pls.find(p => p.id === cell.settlement);
+          const tint = player?.color ? cssColorToPixi(player.color) : 0xffffff;
+
+          if (existingSprite) {
+            // 已有 Sprite → 只更新 tint（O(1)，不重建）
+            existingSprite.tint = tint;
           } else {
-            sm.clear();
+            // 新聚落 → 建 Sprite
+            const tex = houseTextureRef.current;
+            if (tex) {
+              const sprite = new Sprite(tex);
+              sprite.anchor.set(0.5, 0.5);
+              const center = axialToPixel(cell.coord, HEX_SIZE);
+              sprite.position.set(center.x, center.y);
+              sprite.width = HEX_SIZE * 0.9;
+              sprite.height = HEX_SIZE * 0.95;
+              sprite.tint = tint;
+              // 插入 hexContainer（從 settlementGfxMap 的 parent 拿參照）
+              const smGfx = settlementGfxMap.current.get(key);
+              smGfx?.parent?.addChild(sprite);
+              settlementSpriteMap.current.set(key, sprite);
+            }
+          }
+        } else {
+          // 格子無聚落 → 銷毀 Sprite（若有）
+          if (existingSprite) {
+            existingSprite.destroy();
+            settlementSpriteMap.current.delete(key);
           }
         }
       }
@@ -369,11 +396,12 @@ export const PixiBoard: React.FC<PixiBoardProps> = ({
         setZoomScale(vp.scaled);
       });
 
-      // R36 Phase 2b-1 + 2b-2: 並行預載 motif (21) + piece (9) texture
+      // R36 Phase 2b-1 + 2b-2 + 2c: 並行預載 motif (21) + piece (9) + house texture
       const motifEntries = Object.entries(MOTIF_DATA_URLS);
       const pieceEntries = Object.entries(PIECE_DATA_URLS);
+      const dpr = window.devicePixelRatio || 1;
 
-      const [motifTextures, pieceTextures] = await Promise.all([
+      const [motifTextures, pieceTextures, houseTex] = await Promise.all([
         Promise.all(
           motifEntries.map(([, dataUrl]) =>
             Assets.load<Texture>({
@@ -381,7 +409,7 @@ export const PixiBoard: React.FC<PixiBoardProps> = ({
               data: {
                 width: 52,
                 height: 60,
-                resolution: window.devicePixelRatio || 1,
+                resolution: dpr,
               },
             }),
           ),
@@ -393,11 +421,16 @@ export const PixiBoard: React.FC<PixiBoardProps> = ({
               data: {
                 width: 28,
                 height: 28,
-                resolution: window.devicePixelRatio || 1,
+                resolution: dpr,
               },
             }),
           ),
         ),
+        // R36 Phase 2c: white-house texture (shared, single)
+        Assets.load<Texture>({
+          src: HOUSE_DATA_URL,
+          data: { width: 28, height: 28, resolution: dpr },
+        }),
       ]);
 
       const motifTextureMap = new Map<string, Texture>();
@@ -418,9 +451,15 @@ export const PixiBoard: React.FC<PixiBoardProps> = ({
           const dataUrl = PIECE_DATA_URLS[key];
           if (dataUrl) Assets.unload(dataUrl).catch(() => { /* suppress */ });
         }
+        // R36 Phase 2c: house texture cleanup on StrictMode double-invoke
+        try { houseTex.destroy(); } catch { /* suppress */ }
+        Assets.unload(HOUSE_DATA_URL).catch(() => { /* suppress */ });
         app.destroy(true, { children: true, texture: true });
         return;
       }
+
+      // R36 Phase 2c: store house texture ref
+      houseTextureRef.current = houseTex;
 
       // 存入 ref 供 cleanup 使用
       motifTextureMapRef.current = motifTextureMap;
@@ -495,6 +534,15 @@ export const PixiBoard: React.FC<PixiBoardProps> = ({
         if (dataUrl) Assets.unload(dataUrl).catch(() => { /* suppress */ });
       });
       pieceTextureMapRef.current.clear();
+      // R36 Phase 2c: cleanup settlement Sprites
+      settlementSpriteMap.current.forEach(s => { try { s.destroy(); } catch { /* suppress */ } });
+      settlementSpriteMap.current.clear();
+      // R36 Phase 2c: cleanup house texture
+      if (houseTextureRef.current) {
+        try { houseTextureRef.current.destroy(); } catch { /* suppress */ }
+        Assets.unload(HOUSE_DATA_URL).catch(() => { /* suppress */ });
+        houseTextureRef.current = null;
+      }
       if (appRef.current) {
         try {
           appRef.current.destroy(true, { children: true, texture: true });

--- a/src/components/Board/pixiHexUtils.ts
+++ b/src/components/Board/pixiHexUtils.ts
@@ -134,6 +134,32 @@ export function drawLocationDot(g: Graphics, coord: AxialCoord, color: number): 
   g.fill({ color, alpha: 0.85 });
 }
 
+// ─── R36 Phase 2c: White-house texture for Sprite.tint settlement rendering ───
+
+/**
+ * White-house SVG for settlement Sprite.tint染色。
+ * 灰階明度設計（tint 乘色後保留三層立體感）：
+ *   屋頂頂面 #e8e8e8（最亮）、牆正面 #d0d0d0、屋頂側面 #b8b8b8、牆側面 #909090（最暗）
+ *   門 #1a1a1a（近黑，tint 不影響）、投影橢圓 rgba(0,0,0,0.28)（黑色不受 tint）
+ *
+ * 幾何完全參照 SettlementMarker.tsx R24-B 立體房子多邊形座標。
+ * SVG 屬性 kebab-case（stroke-width 等）。
+ */
+export const HOUSE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="-10 -12 20 24" width="28" height="28">
+  <ellipse cx="0" cy="8.5" rx="6" ry="2" fill="rgba(0,0,0,0.28)"/>
+  <rect x="-7" y="0" width="2" height="8" fill="#909090"/>
+  <rect x="-5" y="0" width="11" height="8" fill="#d0d0d0"/>
+  <line x1="-5" y1="8" x2="6" y2="8" stroke="rgba(0,0,0,0.25)" stroke-width="0.8"/>
+  <polygon points="-7,0 -5,0 -5,-9 -7,-7" fill="#b8b8b8"/>
+  <polygon points="-7,-7 -5,-9 7,-9 7,0 -5,0" fill="#e8e8e8"/>
+  <rect x="-1.8" y="3" width="3.6" height="5" rx="0.5" fill="#1a1a1a"/>
+</svg>`;
+
+/**
+ * encodeURIComponent DataURL（⛔ 不用 btoa，與 motif/piece 一致）。
+ */
+export const HOUSE_DATA_URL = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(HOUSE_SVG)}`;
+
 // ─── R36 Phase 2a: Gradient drawing utilities ────────────────────────────────
 
 /**


### PR DESCRIPTION
## R36 Phase 2c — PixiBoard 聚落 2.5D 小房子升級

### 改動範圍

**改動檔案（僅 2 檔）：**
- `src/components/Board/pixiHexUtils.ts` — 新增 `HOUSE_SVG` + `HOUSE_DATA_URL`
- `src/components/Board/PixiBoard.tsx` — settlement 渲染改 Sprite.tint

**不碰：** game logic / gameStore / scoring / multiplayer / cell.settlement 賦值 / validPlacements / MapEditor / motif/piece/terrain (2a/2b)

---

### CEO 修正 1 落實 — encodeURIComponent

`HOUSE_DATA_URL` 使用 `data:image/svg+xml;charset=utf-8,${encodeURIComponent(HOUSE_SVG)}`，與 motifTextures.ts / pieceTextures.ts 一致。未使用 btoa。

### CEO 修正 2 落實 — 2 色截圖確認

`npm run preview` + Playwright 驗收，截圖確認：
- Player 1（橙色）：2.5D 立體小房子，屋頂/牆/門/投影橢圓可辨
- Player 2 bot（粉紫色）：同形狀，不同玩家色染色正確
- 三層灰階明暗差（屋頂頂 #e8e8e8 / 牆正 #d0d0d0 / 屋頂側 #b8b8b8 / 牆側 #909090）在 tint 乘色後仍保留立體感
- 零 console error

---

### updateScene 整合

舊：每次 updateScene 全格 loop → `drawSettlementCircle()` (Graphics clear+redraw)  
新：
- 有聚落 + 已有 Sprite → `sprite.tint = tint`（O(1) uniform update）
- 有聚落 + 無 Sprite → `new Sprite(houseTextureRef.current)` + `addChild`
- 無聚落 + 有 Sprite → `sprite.destroy()` + `delete`

`drawSettlementCircle` import 移除（PixiBoard 不再使用），函式本體保留在 pixiHexUtils（MapEditor 相容）。

---

### Cleanup / 防洩漏

- `settlementSpriteMap.current.forEach(s => s.destroy())` + clear
- `houseTextureRef.current.destroy()` + `Assets.unload(HOUSE_DATA_URL)`
- StrictMode guard：Promise.all 解析後若 `initializedRef` 已 false → `houseTex.destroy()` + unload + return

---

### 驗收結果

| 項目 | 結果 |
|------|------|
| `npm run build` (tsc -b + vite) | 零錯誤零 warning |
| `npx vitest run` | 411/411 通過 |
| `npm run preview` 聚落形狀 | 2.5D 小房子（非圓圈），屋頂/牆/門/投影橢圓可辨 |
| 2 種玩家色染色 | Player1 橙色 + Player2 bot 粉紫色，各自正確 |
| 三層明暗差 | tint 後仍保留立體感 |
| 放置即顯示 | updateScene 觸發正常 |
| console error | 零 |
| pre-push hook | build + 411 vitest 全綠放行 |

---

### Reviewer

建議：`dev-manager`  
Merge 前：CEO 本機 `npm run preview` 親測 + eye review。
