### PR TITLE
feat(R38B): multi-step undo stack — 可連續回收整回合

### DIFF
--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -324,6 +324,7 @@ export const gameStore = create<GameState>((set, get) => ({
         remainingPlacements: SETTLEMENTS_PER_TURN,
         placementsThisTurn: [],
         validPlacements: [],
+        undoStack: [],
       });
       return;
     }
@@ -335,6 +336,7 @@ export const gameStore = create<GameState>((set, get) => ({
       remainingPlacements: SETTLEMENTS_PER_TURN,
       placementsThisTurn: [],
       validPlacements,
+      undoStack: [],
     });
   },
 

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -50,10 +50,13 @@ interface GameState {
   history: GameAction[];
   /** Whether the current player may still undo this turn */
   canUndo: boolean;
-  /** Snapshot used to reverse the most recent undoable action */
-  undoSnapshot: UndoSnapshot | null;
-  /** Tracks whether the undo has already been consumed this turn */
-  undoUsedThisTurn: boolean;
+  /**
+   * Stack of undo snapshots for the current turn (LIFO).
+   * Each undoable action pushes one snapshot; undoLastAction pops the top.
+   * Cleared on endTurn / initGame / drawTerrainCard so cross-turn undo is
+   * impossible.
+   */
+  undoStack: UndoSnapshot[];
   /** Running turn counter (incremented when a new turn begins) */
   turnNumber: number;
 
@@ -217,8 +220,7 @@ export const gameStore = create<GameState>((set, get) => ({
   tileMoveDestinations: [],
   history: [],
   canUndo: false,
-  undoSnapshot: null,
-  undoUsedThisTurn: false,
+  undoStack: [],
   turnNumber: 1,
   gameOptions: { boardSize: 'large', objectiveCount: 3, enableUndo: true },
 
@@ -278,8 +280,7 @@ export const gameStore = create<GameState>((set, get) => ({
       validPlacements: [],
       history: [],
       canUndo: false,
-      undoSnapshot: null,
-      undoUsedThisTurn: false,
+      undoStack: [],
       turnNumber: 1,
       gameOptions: resolvedOptions,
       ...resetTileState(),
@@ -380,7 +381,7 @@ export const gameStore = create<GameState>((set, get) => ({
       timestamp: Date.now(),
     };
 
-    // Build undo snapshot (only the first action per turn is undoable)
+    // Build undo snapshot for this action and push onto the stack
     const snapshot: UndoSnapshot = {
       type: 'PLACE_SETTLEMENT',
       coord,
@@ -388,7 +389,11 @@ export const gameStore = create<GameState>((set, get) => ({
       previousPhase: state.phase,
       acquiredLocationKeys,
       acquiredTileLocs,
+      previousPlacementsThisTurn: state.placementsThisTurn,
     };
+
+    const newUndoStack = [...state.undoStack, snapshot];
+    const enableUndo = state.gameOptions.enableUndo;
 
     if (newRemaining === 0) {
       set({
@@ -399,8 +404,8 @@ export const gameStore = create<GameState>((set, get) => ({
         selectedCell: null,
         acquiredLocations: updatedAcquiredLocations,
         history: [...state.history, action],
-        undoSnapshot: state.undoUsedThisTurn ? null : snapshot,
-        canUndo: state.gameOptions.enableUndo && !state.undoUsedThisTurn,
+        undoStack: newUndoStack,
+        canUndo: enableUndo,
         ...resetTileState(),
       });
     } else {
@@ -421,8 +426,8 @@ export const gameStore = create<GameState>((set, get) => ({
           selectedCell: null,
           acquiredLocations: updatedAcquiredLocations,
           history: [...state.history, action],
-          undoSnapshot: state.undoUsedThisTurn ? null : snapshot,
-          canUndo: state.gameOptions.enableUndo && !state.undoUsedThisTurn,
+          undoStack: newUndoStack,
+          canUndo: enableUndo,
           ...resetTileState(),
         });
       } else {
@@ -433,8 +438,8 @@ export const gameStore = create<GameState>((set, get) => ({
           selectedCell: null,
           acquiredLocations: updatedAcquiredLocations,
           history: [...state.history, action],
-          undoSnapshot: state.undoUsedThisTurn ? null : snapshot,
-          canUndo: state.gameOptions.enableUndo && !state.undoUsedThisTurn,
+          undoStack: newUndoStack,
+          canUndo: enableUndo,
         });
       }
     }
@@ -478,8 +483,7 @@ export const gameStore = create<GameState>((set, get) => ({
         validPlacements: [],
         finalScores,
         canUndo: false,
-        undoSnapshot: null,
-        undoUsedThisTurn: false,
+        undoStack: [],
         turnNumber: nextTurnNumber,
         ...resetTileState(),
       });
@@ -505,8 +509,7 @@ export const gameStore = create<GameState>((set, get) => ({
         currentTerrainCard: null,
         validPlacements: [],
         canUndo: false,
-        undoSnapshot: null,
-        undoUsedThisTurn: false,
+        undoStack: [],
         turnNumber: nextTurnNumber,
         ...resetTileState(),
       });
@@ -713,13 +716,14 @@ export const gameStore = create<GameState>((set, get) => ({
       acquiredTileLocs,
       tileUsed: tileLocation,
       tileUsedIndex: tileIdx !== -1 ? tileIdx : undefined,
+      previousPlacementsThisTurn: state.placementsThisTurn,
     };
 
     set({
       acquiredLocations: updatedAcquiredLocations,
       history: [...state.history, action],
-      undoSnapshot: state.undoUsedThisTurn ? null : snapshot,
-      canUndo: state.gameOptions.enableUndo && !state.undoUsedThisTurn,
+      undoStack: [...state.undoStack, snapshot],
+      canUndo: state.gameOptions.enableUndo,
       ...resetTileState(),
       validPlacements: restoredValid,
     });
@@ -798,12 +802,13 @@ export const gameStore = create<GameState>((set, get) => ({
       tileUsed: tileLocation,
       tileUsedIndex: tileIdx !== -1 ? tileIdx : undefined,
       movedSettlementIdx: idx !== -1 ? idx : undefined,
+      previousPlacementsThisTurn: state.placementsThisTurn,
     };
 
     set({
       history: [...state.history, action],
-      undoSnapshot: state.undoUsedThisTurn ? null : snapshot,
-      canUndo: state.gameOptions.enableUndo && !state.undoUsedThisTurn,
+      undoStack: [...state.undoStack, snapshot],
+      canUndo: state.gameOptions.enableUndo,
       ...resetTileState(),
       validPlacements: restoredValid,
     });
@@ -812,10 +817,13 @@ export const gameStore = create<GameState>((set, get) => ({
   // ── Undo last action ───────────────────────────────
   undoLastAction: () => {
     const state = get();
-    if (!state.canUndo || !state.undoSnapshot || state.undoUsedThisTurn) return;
+    if (!state.canUndo || state.undoStack.length === 0) return;
 
-    const snap = state.undoSnapshot;
+    // Pop the top snapshot (most recent action)
+    const snap = state.undoStack[state.undoStack.length - 1];
+    const newStack = state.undoStack.slice(0, -1);
     const currentPlayer = state.players[state.currentPlayerIndex];
+    const enableUndo = state.gameOptions.enableUndo;
 
     if (snap.type === 'PLACE_SETTLEMENT' && snap.coord) {
       // Remove settlement from board
@@ -842,13 +850,18 @@ export const gameStore = create<GameState>((set, get) => ({
         key => !snap.acquiredLocationKeys.includes(key)
       );
 
-      // Restore validPlacements
+      // Restore placementsThisTurn (backwards-compat: old snapshots lack the field)
+      const restoredPlacementsThisTurn =
+        snap.previousPlacementsThisTurn ?? state.placementsThisTurn.slice(0, -1);
+
+      // Restore validPlacements using the restored placementsThisTurn
       const restoredValid =
         state.currentTerrainCard
           ? getValidPlacements(
             state.board,
             state.currentTerrainCard.terrain,
-            currentPlayer.id
+            currentPlayer.id,
+            restoredPlacementsThisTurn
           )
           : [];
 
@@ -856,10 +869,10 @@ export const gameStore = create<GameState>((set, get) => ({
         remainingPlacements: snap.previousRemainingPlacements,
         phase: snap.previousPhase,
         acquiredLocations: restoredAcquired,
+        placementsThisTurn: restoredPlacementsThisTurn,
         validPlacements: restoredValid,
-        canUndo: false,
-        undoSnapshot: null,
-        undoUsedThisTurn: true,
+        undoStack: newStack,
+        canUndo: enableUndo && newStack.length > 0,
         history: state.history.slice(0, -1),
         selectedCell: null,
       });
@@ -899,12 +912,16 @@ export const gameStore = create<GameState>((set, get) => ({
         key => !snap.acquiredLocationKeys.includes(key)
       );
 
+      const restoredPlacementsThisTurn =
+        snap.previousPlacementsThisTurn ?? state.placementsThisTurn;
+
       const restoredValid =
         state.currentTerrainCard
           ? getValidPlacements(
             state.board,
             state.currentTerrainCard.terrain,
-            currentPlayer.id
+            currentPlayer.id,
+            restoredPlacementsThisTurn
           )
           : [];
 
@@ -912,10 +929,10 @@ export const gameStore = create<GameState>((set, get) => ({
         remainingPlacements: snap.previousRemainingPlacements,
         phase: snap.previousPhase,
         acquiredLocations: restoredAcquired,
+        placementsThisTurn: restoredPlacementsThisTurn,
         validPlacements: restoredValid,
-        canUndo: false,
-        undoSnapshot: null,
-        undoUsedThisTurn: true,
+        undoStack: newStack,
+        canUndo: enableUndo && newStack.length > 0,
         history: state.history.slice(0, -1),
         selectedCell: null,
       });
@@ -947,22 +964,26 @@ export const gameStore = create<GameState>((set, get) => ({
         if (usedTile) usedTile.usedThisTurn = false;
       }
 
+      const restoredPlacementsThisTurn =
+        snap.previousPlacementsThisTurn ?? state.placementsThisTurn;
+
       const restoredValid =
         state.currentTerrainCard
           ? getValidPlacements(
             state.board,
             state.currentTerrainCard.terrain,
-            currentPlayer.id
+            currentPlayer.id,
+            restoredPlacementsThisTurn
           )
           : [];
 
       set({
         remainingPlacements: snap.previousRemainingPlacements,
         phase: snap.previousPhase,
+        placementsThisTurn: restoredPlacementsThisTurn,
         validPlacements: restoredValid,
-        canUndo: false,
-        undoSnapshot: null,
-        undoUsedThisTurn: true,
+        undoStack: newStack,
+        canUndo: enableUndo && newStack.length > 0,
         history: state.history.slice(0, -1),
         selectedCell: null,
       });

--- a/src/store/persistence.test.ts
+++ b/src/store/persistence.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { saveGame, loadGame, clearSave, SAVE_VERSION } from './persistence';
 import { GamePhase } from '../types';
-import { createDefaultBoard } from '../core/board';
+import { createDefaultBoard, serializeBoard } from '../core/board';
 
 const STORAGE_KEY = 'kingdom-builder-save';
 
@@ -25,8 +25,7 @@ function makeMinimalState() {
     tileMoveDestinations: [],
     history: [],
     canUndo: false,
-    undoSnapshot: null,
-    undoUsedThisTurn: false,
+    undoStack: [] as import('../types/history').UndoSnapshot[],
     turnNumber: 0,
   };
 }
@@ -81,5 +80,70 @@ describe('persistence', () => {
     expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
     clearSave();
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  // ── Backwards-compat: old saves with undoSnapshot / undoUsedThisTurn ──────
+
+  it('loads old save (undoSnapshot field, no undoStack) without clearSave', () => {
+    // Simulate a pre-Phase-B save: has undoSnapshot/undoUsedThisTurn, no undoStack.
+    // Board must be serialized with serializeBoard (same as saveGame does).
+    const base = makeMinimalState();
+    const oldStylePayload = {
+      saveVersion: SAVE_VERSION,
+      state: {
+        ...base,
+        board: serializeBoard(base.board),
+        undoStack: undefined,
+        undoSnapshot: {
+          type: 'PLACE_SETTLEMENT',
+          coord: { q: 1, r: 2 },
+          previousRemainingPlacements: 2,
+          previousPhase: GamePhase.Setup,
+          acquiredLocationKeys: [],
+          acquiredTileLocs: [],
+        },
+        undoUsedThisTurn: false,
+      },
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(oldStylePayload));
+
+    const loaded = loadGame();
+
+    // Must load successfully (not clearSave + return null)
+    expect(loaded).not.toBeNull();
+    // undoStack should be populated from the old undoSnapshot
+    expect(loaded!.undoStack).toHaveLength(1);
+    expect(loaded!.undoStack[0].type).toBe('PLACE_SETTLEMENT');
+    // LocalStorage key must still exist (save was NOT wiped)
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+  });
+
+  it('loads old save with null undoSnapshot as empty undoStack', () => {
+    const base = makeMinimalState();
+    const oldStylePayload = {
+      saveVersion: SAVE_VERSION,
+      state: {
+        ...base,
+        board: serializeBoard(base.board),
+        undoStack: undefined,
+        undoSnapshot: null,
+        undoUsedThisTurn: true,
+      },
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(oldStylePayload));
+
+    const loaded = loadGame();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.undoStack).toHaveLength(0);
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+  });
+
+  it('new-format save (undoStack present) loads without migration', () => {
+    const state = makeMinimalState();
+    saveGame(state);
+
+    const loaded = loadGame();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.undoStack).toHaveLength(0);
   });
 });

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -32,8 +32,12 @@ export interface SerializableGameState {
   tileMoveDestinations: AxialCoord[];
   history: GameAction[];
   canUndo: boolean;
-  undoSnapshot: UndoSnapshot | null;
-  undoUsedThisTurn: boolean;
+  /**
+   * Multi-step undo stack (Phase B). Replaces the old undoSnapshot/undoUsedThisTurn
+   * fields. SAVE_VERSION is intentionally kept at 1; loadGame() handles old saves
+   * via the backwards-compat fallback below.
+   */
+  undoStack: UndoSnapshot[];
   turnNumber: number;
 }
 
@@ -63,7 +67,11 @@ export function loadGame(): SerializableGameState | null {
   if (!raw) return null;
 
   try {
-    const parsed: SaveSchema = JSON.parse(raw) as SaveSchema;
+    // Parse as a loose type so we can read both old and new fields
+    const parsed = JSON.parse(raw) as {
+      saveVersion: number;
+      state: Record<string, unknown>;
+    };
     if (parsed.saveVersion !== SAVE_VERSION) {
       clearSave();
       return null;
@@ -73,9 +81,21 @@ export function loadGame(): SerializableGameState | null {
     const boardData = parsed.state.board as unknown as ReturnType<typeof serializeBoard>;
     const board = deserializeBoard(boardData);
 
+    // Backwards-compat: old saves (pre-Phase-B) have undoSnapshot / undoUsedThisTurn
+    // instead of undoStack. Migrate gracefully without clearing the save.
+    const rawState = parsed.state as Record<string, unknown> & {
+      undoStack?: UndoSnapshot[];
+      undoSnapshot?: UndoSnapshot | null;
+      undoUsedThisTurn?: boolean;
+    };
+    const undoStack: UndoSnapshot[] =
+      rawState.undoStack ??
+      (rawState.undoSnapshot ? [rawState.undoSnapshot] : []);
+
     return {
-      ...parsed.state,
+      ...(rawState as unknown as SerializableGameState),
       board,
+      undoStack,
     };
   } catch {
     clearSave();

--- a/src/test/gameStore.undo.test.ts
+++ b/src/test/gameStore.undo.test.ts
@@ -4,8 +4,8 @@
  * These tests exercise:
  *  - history accumulates on each placement
  *  - undoLastAction restores board & player state
- *  - each turn allows only 1 undo
- *  - canUndo is reset correctly on endTurn
+ *  - multi-step undo: can undo every action back to start of turn
+ *  - canUndo is reset correctly on endTurn / new game
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -115,29 +115,34 @@ describe('History & Undo', () => {
       expect(useGameStore.getState().canUndo).toBe(true);
     });
 
-    it('is false after undo is consumed', () => {
+    it('is false after all actions are undone back to start of turn', () => {
       useGameStore.getState().placeSettlement(firstValidPlacement());
       useGameStore.getState().undoLastAction();
       expect(useGameStore.getState().canUndo).toBe(false);
     });
 
-    it('remains false for subsequent placements after undo is used', () => {
-      // Use the 1 undo allowance
+    it('remains true after partial undo when more actions remain on stack', () => {
+      useGameStore.getState().placeSettlement(firstValidPlacement());
+      useGameStore.getState().placeSettlement(firstValidPlacement());
+      // Stack has 2 snapshots; after 1 undo still 1 left
+      useGameStore.getState().undoLastAction();
+      expect(useGameStore.getState().canUndo).toBe(true);
+    });
+
+    it('is true after placement even if undo was already used earlier this turn', () => {
+      // Phase B: undo does NOT consume the turn allowance — stack-based
       useGameStore.getState().placeSettlement(firstValidPlacement());
       useGameStore.getState().undoLastAction();
 
-      // Place another settlement – no more undo available this turn
+      // Place again — canUndo should become true again
       useGameStore.getState().placeSettlement(firstValidPlacement());
-      expect(useGameStore.getState().canUndo).toBe(false);
+      expect(useGameStore.getState().canUndo).toBe(true);
     });
 
     it('resets to false at the start of the next turn', () => {
-      // Use undo this turn
       useGameStore.getState().placeSettlement(firstValidPlacement());
-      useGameStore.getState().undoLastAction();
-
       // Complete the turn
-      for (let i = 0; i < 3; i++) {
+      for (let i = 0; i < 2; i++) {
         useGameStore.getState().placeSettlement(firstValidPlacement());
       }
       useGameStore.getState().endTurn();
@@ -216,31 +221,79 @@ describe('History & Undo', () => {
     });
   });
 
-  // ── 1 undo per turn enforcement ──────────────────────────────────────────
+  // ── Multi-step undo ──────────────────────────────────────────────────────
 
-  describe('1-undo-per-turn rule', () => {
-    it('allows exactly 1 undo per turn', () => {
+  describe('multi-step undo', () => {
+    it('allows undo of every action in the turn (3 placements → 3 undos)', () => {
+      const coords: ReturnType<typeof firstValidPlacement>[] = [];
+      for (let i = 0; i < 3; i++) {
+        const coord = firstValidPlacement();
+        coords.push(coord);
+        useGameStore.getState().placeSettlement(coord);
+      }
+      expect(useGameStore.getState().undoStack.length).toBe(3);
+
+      // Undo each one
+      for (let i = 2; i >= 0; i--) {
+        useGameStore.getState().undoLastAction();
+        expect(useGameStore.getState().board.getSettlement(coords[i])).toBeUndefined();
+      }
+      expect(useGameStore.getState().undoStack.length).toBe(0);
+      expect(useGameStore.getState().canUndo).toBe(false);
+    });
+
+    it('second placement after undo is also undoable', () => {
       const coord1 = firstValidPlacement();
       useGameStore.getState().placeSettlement(coord1);
 
-      // First undo: allowed
+      // Undo first placement
       useGameStore.getState().undoLastAction();
-      expect(useGameStore.getState().canUndo).toBe(false);
+      expect(useGameStore.getState().board.getSettlement(coord1)).toBeUndefined();
 
-      // Place again – undo quota consumed
+      // Place again — new snapshot pushed
       const coord2 = firstValidPlacement();
       useGameStore.getState().placeSettlement(coord2);
-      expect(useGameStore.getState().canUndo).toBe(false);
+      expect(useGameStore.getState().canUndo).toBe(true);
 
-      // Second undo attempt: should be ignored
+      // Undo second placement
       useGameStore.getState().undoLastAction();
-      const { board } = useGameStore.getState();
-      // Settlement at coord2 must still be on the board
-      expect(board.getSettlement(coord2)).toBe(1);
+      expect(useGameStore.getState().board.getSettlement(coord2)).toBeUndefined();
+      expect(useGameStore.getState().canUndo).toBe(false);
     });
 
-    it('refreshes the undo allowance after endTurn', () => {
-      // Player 1: consume undo, complete turn
+    it('undoStack is empty after endTurn', () => {
+      useGameStore.getState().placeSettlement(firstValidPlacement());
+      useGameStore.getState().placeSettlement(firstValidPlacement());
+      useGameStore.getState().placeSettlement(firstValidPlacement());
+      useGameStore.getState().endTurn();
+      expect(useGameStore.getState().undoStack).toHaveLength(0);
+      expect(useGameStore.getState().canUndo).toBe(false);
+    });
+
+    it('undo restores remainingPlacements correctly after each step', () => {
+      const initial = useGameStore.getState().remainingPlacements;
+      useGameStore.getState().placeSettlement(firstValidPlacement());
+      useGameStore.getState().placeSettlement(firstValidPlacement());
+      expect(useGameStore.getState().remainingPlacements).toBe(initial - 2);
+
+      useGameStore.getState().undoLastAction();
+      expect(useGameStore.getState().remainingPlacements).toBe(initial - 1);
+
+      useGameStore.getState().undoLastAction();
+      expect(useGameStore.getState().remainingPlacements).toBe(initial);
+    });
+
+    it('canUndo becomes true again after new placement following undo', () => {
+      useGameStore.getState().placeSettlement(firstValidPlacement());
+      useGameStore.getState().undoLastAction();
+      expect(useGameStore.getState().canUndo).toBe(false);
+
+      useGameStore.getState().placeSettlement(firstValidPlacement());
+      expect(useGameStore.getState().canUndo).toBe(true);
+    });
+
+    it('refreshes undoStack after endTurn', () => {
+      // Player 1: undo some, complete turn
       useGameStore.getState().placeSettlement(firstValidPlacement());
       useGameStore.getState().undoLastAction();
       for (let i = 0; i < 3; i++) {
@@ -252,6 +305,7 @@ describe('History & Undo', () => {
       useGameStore.getState().drawTerrainCard();
       useGameStore.getState().placeSettlement(firstValidPlacement());
       expect(useGameStore.getState().canUndo).toBe(true);
+      expect(useGameStore.getState().undoStack).toHaveLength(1);
     });
   });
 
@@ -264,11 +318,11 @@ describe('History & Undo', () => {
       expect(useGameStore.getState().history).toHaveLength(0);
     });
 
-    it('resets canUndo and undoSnapshot on new game', () => {
+    it('resets canUndo and undoStack on new game', () => {
       useGameStore.getState().placeSettlement(firstValidPlacement());
       useGameStore.getState().initGame(2);
       expect(useGameStore.getState().canUndo).toBe(false);
-      expect(useGameStore.getState().undoSnapshot).toBeNull();
+      expect(useGameStore.getState().undoStack).toHaveLength(0);
     });
   });
 
@@ -287,6 +341,33 @@ describe('History & Undo', () => {
       expect(useGameStore.getState().board.getSettlement(coord)).toBe(1);
 
       useGameStore.getState().undoLastAction();
+      expect(useGameStore.getState().board.getSettlement(coord)).toBeUndefined();
+    });
+  });
+
+  // ── Old snapshot backwards-compat ───────────────────────────────────────
+
+  describe('old snapshot backwards-compat (no previousPlacementsThisTurn)', () => {
+    it('does not crash when undoing a snapshot lacking previousPlacementsThisTurn', () => {
+      const coord = firstValidPlacement();
+      useGameStore.getState().placeSettlement(coord);
+
+      // Simulate an old-format snapshot (pre-Phase-B) that lacks the new field
+      useGameStore.setState(() => ({
+        undoStack: [
+          {
+            type: 'PLACE_SETTLEMENT' as const,
+            coord,
+            previousRemainingPlacements: 3,
+            previousPhase: GamePhase.PlaceSettlements,
+            acquiredLocationKeys: [],
+            acquiredTileLocs: [],
+            // previousPlacementsThisTurn intentionally absent
+          },
+        ],
+      }));
+
+      expect(() => useGameStore.getState().undoLastAction()).not.toThrow();
       expect(useGameStore.getState().board.getSettlement(coord)).toBeUndefined();
     });
   });

--- a/src/test/gameStore.undo.tileCopy.test.ts
+++ b/src/test/gameStore.undo.tileCopy.test.ts
@@ -64,9 +64,8 @@ describe('fix #125 — duplicate location tile undo', () => {
             }
       ),
       canUndo: true,
-      undoUsedThisTurn: false,
       // Snapshot targets the SECOND tile (index 1)
-      undoSnapshot: makeTilePlacementSnapshot(1, 'Farm'),
+      undoStack: [makeTilePlacementSnapshot(1, 'Farm')],
     }));
 
     useGameStore.getState().undoLastAction();
@@ -95,8 +94,7 @@ describe('fix #125 — duplicate location tile undo', () => {
             }
       ),
       canUndo: true,
-      undoUsedThisTurn: false,
-      undoSnapshot: makeTilePlacementSnapshot(0, 'Farm'),
+      undoStack: [makeTilePlacementSnapshot(0, 'Farm')],
     }));
 
     useGameStore.getState().undoLastAction();
@@ -125,8 +123,7 @@ describe('fix #125 — duplicate location tile undo', () => {
             }
       ),
       canUndo: true,
-      undoUsedThisTurn: false,
-      undoSnapshot: makeTilePlacementSnapshot(0, 'Farm'),
+      undoStack: [makeTilePlacementSnapshot(0, 'Farm')],
     }));
 
     useGameStore.getState().undoLastAction();

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -24,11 +24,10 @@ export interface GameAction {
 }
 
 /**
- * Internal snapshot used to reverse the last action (undo support).
- * One snapshot is stored at most, covering the most recent undoable action
- * in the current turn. A new snapshot is only created when `undoUsedThisTurn`
- * is false; once the player has consumed their undo for the turn the snapshot
- * is set to null and `canUndo` stays false for the remainder of that turn.
+ * Internal snapshot used to reverse a single undoable action.
+ * Stored in a stack (undoStack) in GameState; the top of the stack is the most
+ * recent action. Popping and reversing allows the player to step back one
+ * action at a time until the stack is empty (start of the current turn).
  */
 export interface UndoSnapshot {
   type: GameActionType;
@@ -59,4 +58,11 @@ export interface UndoSnapshot {
   tileUsedIndex?: number;
   /** Settlement index in player.settlements that was removed (TILE_MOVE only) */
   movedSettlementIdx?: number;
+  /**
+   * Snapshot of placementsThisTurn BEFORE this action was applied.
+   * Restored when undoing to support correct adjacency-rule recalculation.
+   * Backwards-compat: old snapshots lack this field → fallback to
+   * state.placementsThisTurn.slice(0, -1) when undefined.
+   */
+  previousPlacementsThisTurn?: AxialCoord[];
 }


### PR DESCRIPTION
## 範圍

R38 Phase B — 將 gameStore 的單次 undo（`undoSnapshot` + `undoUsedThisTurn` 旗標）改為可連續多步收回整回合的 undo 堆疊（`undoStack`）。

---

## 改動檔案

| 檔案 | 說明 |
|------|------|
| `src/types/history.ts` | `UndoSnapshot` 新增 `previousPlacementsThisTurn?: AxialCoord[]`（向下相容，舊 snapshot 無此欄 fallback slice） |
| `src/store/gameStore.ts` | 移除 `undoSnapshot/undoUsedThisTurn`；新增 `undoStack: UndoSnapshot[]`；每個放置/tile 動作 push snapshot；`undoLastAction` 改為 pop 頂端並反轉；`endTurn/initGame/drawTerrainCard` 清空堆疊 |
| `src/store/persistence.ts` | `SerializableGameState` 換成 `undoStack`；SAVE_VERSION 維持 1；`loadGame()` 加向下相容 fallback |
| `src/store/persistence.test.ts` | 更新 `makeMinimalState()`；新增舊格式相容載入測試 3 個 |
| `src/test/gameStore.undo.test.ts` | 替換「1-undo-per-turn」測試為多步 undo 測試；新增舊 snapshot 無 `previousPlacementsThisTurn` 不崩潰測試 |
| `src/test/gameStore.undo.tileCopy.test.ts` | 更新 `setState` 注入為 `undoStack` 陣列 |

---

## undo 堆疊設計

- **Push**：`placeSettlement / applyTilePlacement / applyTileMove` 每次都 push 一個 snapshot，不再有「每回合只能 1 次」限制
- **Pop**：`undoLastAction` pop 頂端 snapshot，反轉動作（移除聚落 / 還原 remainingPlacements / un-mark tile.usedThisTurn / 還原 placementsThisTurn / 重算 validPlacements）
- **清空**：`endTurn / initGame / drawTerrainCard` 清空堆疊，跨回合不可 undo
- **canUndo**：`stack.length > 0 && enableUndo`

---

## 存檔向下相容做法（無 bump 無 clear）

CEO 硬修正遵守：SAVE_VERSION 維持 1，不 clearSave 舊存檔。

```ts
// loadGame() 向下相容 fallback
const undoStack: UndoSnapshot[] =
  rawState.undoStack ??
  (rawState.undoSnapshot ? [rawState.undoSnapshot] : []);
```

- 舊存檔有 `undoSnapshot`（非 null）→ 轉成單元素陣列
- 舊存檔有 `undoSnapshot: null` → 空陣列
- 新存檔有 `undoStack` → 直接使用
- 老闆進行中的遊戲載入不被洗

---

## 多步 undo 截圖（本機 preview 驗證）

**放置 1 個聚落後（"1 of 3"）：**
- Placements left: 2，undo 按鈕 enabled

**按 undo 後（"0 of 3"）：**
- Placements left: 3，棋盤聚落消失，無鬼影
- 再放置再 undo → 同樣成功（連續多次有效）

Playwright E2E 結果：
```
Placed 1: true
After place 1: 1 of 3
After undo 1: 0 of 3      ← 正確復原
Placed 2: true
After place 2: 1 of 3
After undo 2: 0 of 3      ← 多步 undo 有效
PASS: 0 console errors
```

---

## Build + Vitest 結果

```
npm run build   → tsc -b && vite build ✓ 零 error
npx vitest run  → 35 test files, 420 tests passed (0 failed)
```

新增/更新測試（涵蓋）：
- 連續 undo 3 次全部收回
- undo 後 canUndo 正確（stack 空 → false）
- endTurn 後 undoStack 清空
- 舊存檔相容載入（undoSnapshot → undoStack migration）
- 舊 snapshot 無 `previousPlacementsThisTurn` 不崩潰

---

## ⚠️ 需要雙審才可 merge

此 PR 改動 `gameStore` state shape + `types/history` + `persistence` 存檔格式，依計劃安全判斷必須：

- **harper (CISO)** 審查重點：localStorage 操作無 XSS 向量；undoStack 不可跨回合跨玩家操控（guard 已確認）；clearSave 不影響其他 key；SAVE_VERSION 不 bump 不造成資料洩漏
- **gray (CPO)** 審查重點：多步 undo 行為符合設計（每個動作可逐步收回）；placementsThisTurn 正確還原（adjacency rule 不破壞）；extra-placement tile 也可逐步收回

⛔ **請勿在 harper + gray 雙審核准前 merge**

---

**Reviewers 建議**：harper、gray
