### PR TITLE
feat(menu): T3 - Other Games portal section (Herbalism + Sudoku)

### DIFF
--- a/src/components/Menu/MainMenu.tsx
+++ b/src/components/Menu/MainMenu.tsx
@@ -332,6 +332,76 @@ export function MainMenu({
           )}
         </div>
 
+        {/* Other Games portal */}
+        <div className="w-full" style={{ borderTop: '1px solid var(--card-border)', paddingTop: '1rem' }}>
+          <p
+            className="text-center text-label font-body mb-3"
+            style={{
+              color: 'var(--color-stone-500)',
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+            }}
+          >
+            {t('menu.otherGames')}
+          </p>
+          <div className="w-full flex gap-3">
+            {/* Gress Herbalism */}
+            <a
+              href="#herbalism"
+              className="flex-1 flex flex-col items-center gap-1 py-3 px-2 rounded-14 transition"
+              style={{
+                backgroundColor: 'var(--color-warm-cream-200)',
+                border: '1px solid var(--card-border)',
+                color: 'var(--color-stone-700)',
+                textDecoration: 'none',
+              }}
+              onMouseEnter={(e) => {
+                (e.currentTarget as HTMLAnchorElement).style.backgroundColor = 'var(--color-warm-cream-300)';
+                (e.currentTarget as HTMLAnchorElement).style.borderColor = 'var(--color-wine-400)';
+              }}
+              onMouseLeave={(e) => {
+                (e.currentTarget as HTMLAnchorElement).style.backgroundColor = 'var(--color-warm-cream-200)';
+                (e.currentTarget as HTMLAnchorElement).style.borderColor = 'var(--card-border)';
+              }}
+            >
+              <span style={{ fontSize: '1.25rem', lineHeight: 1 }} aria-hidden="true">🌿</span>
+              <span className="font-body font-semibold" style={{ fontSize: 'var(--type-body-sm)' }}>
+                {t('menu.herbalism')}
+              </span>
+              <span className="font-body" style={{ fontSize: 'var(--type-label)', color: 'var(--color-stone-500)' }}>
+                {t('menu.herbalismDesc')}
+              </span>
+            </a>
+            {/* Sudoku */}
+            <a
+              href="#sudoku"
+              className="flex-1 flex flex-col items-center gap-1 py-3 px-2 rounded-14 transition"
+              style={{
+                backgroundColor: 'var(--color-warm-cream-200)',
+                border: '1px solid var(--card-border)',
+                color: 'var(--color-stone-700)',
+                textDecoration: 'none',
+              }}
+              onMouseEnter={(e) => {
+                (e.currentTarget as HTMLAnchorElement).style.backgroundColor = 'var(--color-warm-cream-300)';
+                (e.currentTarget as HTMLAnchorElement).style.borderColor = 'var(--color-wine-400)';
+              }}
+              onMouseLeave={(e) => {
+                (e.currentTarget as HTMLAnchorElement).style.backgroundColor = 'var(--color-warm-cream-200)';
+                (e.currentTarget as HTMLAnchorElement).style.borderColor = 'var(--card-border)';
+              }}
+            >
+              <span style={{ fontSize: '1.25rem', lineHeight: 1 }} aria-hidden="true">🔢</span>
+              <span className="font-body font-semibold" style={{ fontSize: 'var(--type-body-sm)' }}>
+                {t('menu.sudoku')}
+              </span>
+              <span className="font-body" style={{ fontSize: 'var(--type-label)', color: 'var(--color-stone-500)' }}>
+                {t('menu.sudokuDesc')}
+              </span>
+            </a>
+          </div>
+        </div>
+
         {/* Clear save (if exists) */}
         {hasSave && (
           <button

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -87,6 +87,11 @@ export const en = {
     replayLibrary: 'Replay Library',
     settings: 'Settings',
     back: 'Back',
+    otherGames: 'More Games',
+    herbalism: 'Gress Herbalism',
+    herbalismDesc: 'Herbal Board Game',
+    sudoku: 'Sudoku',
+    sudokuDesc: 'Number Puzzle',
   },
   settings: {
     heading: 'Settings',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -87,6 +87,11 @@ export const zhTW = {
     replayLibrary: '回放記錄',
     settings: '設定',
     back: '返回',
+    otherGames: '更多遊戲',
+    herbalism: '本草棋遊',
+    herbalismDesc: '中草藥桌遊',
+    sudoku: '數獨',
+    sudokuDesc: '數字謎題',
   },
   settings: {
     heading: '設定',


### PR DESCRIPTION
## Summary
- 在 MainMenu 主按鈕下方加「More Games / 更多遊戲」區塊，包含本草棋遊（`#herbalism`）與數獨（`#sudoku`）兩個 placeholder 入口
- 視覺沿用現有 parchment + wine design tokens（`--color-warm-cream-200`、`--card-border`、`--color-wine-400` hover），羊皮紙卡片風格
- i18n 補 zh-TW / en 兩種語系：`menu.otherGames`、`menu.herbalism`、`menu.herbalismDesc`、`menu.sudoku`、`menu.sudokuDesc`
- 既有單人/多人/繼續按鈕完全不受影響

## Test plan
- [x] `npm run build`（tsc -b + vite build）全綠
- [x] `npx vitest run` 36 files / 656 tests 全綠
- [x] pre-push hook 自動跑 build + vitest 通過
- [x] 截圖驗證：desktop 1440 含新區塊（`/tmp/t3-portal-desktop.png`）
- [x] 截圖驗證：mobile 375 含新區塊（`/tmp/t3-portal-mobile.png`）
- [x] 截圖驗證：Single Player 按鈕點擊後正確進入 GameSetup（`/tmp/t3-portal-gamesetup.png`）

## 改動檔案
- `src/components/Menu/MainMenu.tsx` — 加 Other Games 區塊
- `src/i18n/locales/en.ts` — 加 4 個 menu key
- `src/i18n/locales/zh-TW.ts` — 加 4 個 menu key

🤖 Generated with [Claude Code](https://claude.com/claude-code)