### PR TITLE
fix(r41-p0): fix multiplayer white screen — hydrate Board from wire JSON

### DIFF
--- a/src/components/Game/MultiplayerSetup.tsx
+++ b/src/components/Game/MultiplayerSetup.tsx
@@ -5,6 +5,7 @@ import { useGameStore } from '../../store/gameStore';
 import { useMultiplayerStore } from '../../store/multiplayerStore';
 import { extractSerializableState } from '../../multiplayer/stateSerializer';
 import { useTranslation } from 'react-i18next';
+import type { RoomPlayer } from '../../multiplayer/types';
 
 interface MultiplayerSetupProps {
   onBack: () => void;
@@ -43,15 +44,15 @@ export function MultiplayerSetup({ onBack, onGameStarted }: MultiplayerSetupProp
   } = useMultiplayerStore();
 
   const sortedPlayers = useMemo(() => {
-    return room?.players.slice().sort((a, b) => a.id - b.id) ?? [];
+    return room?.players.slice().sort((a: RoomPlayer, b: RoomPlayer) => a.id - b.id) ?? [];
   }, [room]);
 
   const isHost = room && localPlayerId === room.hostPlayerId;
-  const me = sortedPlayers.find((p) => p.id === localPlayerId);
+  const me = sortedPlayers.find((p: RoomPlayer) => p.id === localPlayerId);
   const canHostStart =
     !!room &&
     sortedPlayers.length >= 2 &&
-    sortedPlayers.every((p) => p.id === room.hostPlayerId || p.ready);
+    sortedPlayers.every((p: RoomPlayer) => p.id === room.hostPlayerId || p.ready);
 
   useEffect(() => {
     if (mode === 'in_game') {
@@ -79,8 +80,8 @@ export function MultiplayerSetup({ onBack, onGameStarted }: MultiplayerSetupProp
     if (!room) return;
     const configs: PlayerConfig[] = room.players
       .slice()
-      .sort((a, b) => a.id - b.id)
-      .map((p) => ({
+      .sort((a: RoomPlayer, b: RoomPlayer) => a.id - b.id)
+      .map((p: RoomPlayer) => ({
         name: p.name,
         type: 'human',
         difficulty: BotDifficulty.Medium,
@@ -202,7 +203,7 @@ export function MultiplayerSetup({ onBack, onGameStarted }: MultiplayerSetupProp
             </div>
 
             <div className="space-y-2 mb-4">
-              {sortedPlayers.map((p) => (
+              {sortedPlayers.map((p: RoomPlayer) => (
                 <div
                   key={p.id}
                   className="flex items-center justify-between p-2 rounded-8"

--- a/src/multiplayer/stateSerializer.ts
+++ b/src/multiplayer/stateSerializer.ts
@@ -1,13 +1,38 @@
 import type { SerializableGameState } from '../store/persistence';
+import { deserializeBoard, serializeBoard } from '../core/board';
 import { useGameStore } from '../store/gameStore';
 
 export function extractSerializableState(): SerializableGameState {
   const state = useGameStore.getState();
-  return Object.fromEntries(
+  const plain = Object.fromEntries(
     Object.entries(state).filter(([, value]) => typeof value !== 'function')
   ) as SerializableGameState;
+
+  // `board.cells` is a Map; JSON.stringify converts it to `{}` (empty object).
+  // Serialise it to an [key, HexCell][] array so the wire payload is valid JSON
+  // and can be reconstructed on the receiving end via deserializeBoard().
+  return {
+    ...plain,
+    board: serializeBoard(plain.board) as unknown as import('../core/board').Board,
+  };
 }
 
+/**
+ * Hydrate a SerializableGameState received over the wire (plain JSON) into
+ * the live gameStore. The critical step is restoring `board` from its
+ * serialised form (cells as an array of [key, HexCell] tuples) back to a
+ * proper Board class instance with a Map and all prototype methods.
+ *
+ * This mirrors the deserialization logic in persistence.ts loadGame() so
+ * that the multiplayer path behaves identically to the single-player
+ * "Continue" restore path.
+ */
 export function hydrateSerializableState(next: SerializableGameState): void {
-  useGameStore.setState(next);
+  // `next.board` arrives as a plain object with `cells` as an array of
+  // [string, HexCell] tuples (JSON-serialised Map). Cast it to the shape
+  // that deserializeBoard expects.
+  const boardData = next.board as unknown as ReturnType<typeof serializeBoard>;
+  const board = deserializeBoard(boardData);
+
+  useGameStore.setState({ ...next, board });
 }

--- a/src/test/stateSerializer.test.ts
+++ b/src/test/stateSerializer.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Board, serializeBoard } from '../core/board';
+import { Terrain } from '../core/terrain';
+import type { HexCell } from '../types';
+import type { SerializableGameState } from '../store/persistence';
+
+// Mock the gameStore to avoid zustand / React environment issues in unit tests
+let capturedState: unknown = null;
+let mockGetState: () => Record<string, unknown> = () => ({});
+
+vi.mock('../store/gameStore', () => ({
+  useGameStore: {
+    getState: vi.fn(() => mockGetState()),
+    setState: vi.fn((next: unknown) => { capturedState = next; }),
+  },
+}));
+
+import { hydrateSerializableState, extractSerializableState } from '../multiplayer/stateSerializer';
+
+describe('extractSerializableState – board serialisation', () => {
+  it('serialises board.cells Map to an array so JSON.stringify does not produce {}', () => {
+    const board = new Board(10, 10);
+    board.setCell({ coord: { q: 1, r: 2 }, terrain: Terrain.Grass, settlement: undefined });
+    board.setCell({ coord: { q: 3, r: 4 }, terrain: Terrain.Forest, settlement: 1 });
+
+    mockGetState = () => ({ board, players: [], currentPlayerIndex: 0 });
+
+    const extracted = extractSerializableState();
+
+    // After JSON round-trip (as WebSocket JSON.stringify would do), cells must be an array
+    const jsonStr = JSON.stringify(extracted);
+    const parsed = JSON.parse(jsonStr);
+
+    expect(Array.isArray(parsed.board.cells)).toBe(true);
+    expect(parsed.board.cells).toHaveLength(2);
+    // Width/height preserved
+    expect(parsed.board.width).toBe(10);
+    expect(parsed.board.height).toBe(10);
+  });
+});
+
+describe('hydrateSerializableState – board hydration', () => {
+  beforeEach(() => {
+    capturedState = null;
+  });
+
+  it('converts plain-JSON board (cells as tuple array) into Board instance', () => {
+    // Build a real board, then simulate what JSON.parse produces from the wire
+    const board = new Board(10, 10);
+    const cell: HexCell = { coord: { q: 2, r: 3 }, terrain: Terrain.Grass, settlement: 1 };
+    board.setCell(cell);
+
+    const serialised = serializeBoard(board);
+    // Round-trip through JSON (as the wire would deliver it)
+    const wireBoard = JSON.parse(JSON.stringify(serialised));
+
+    const fakeState = {
+      board: wireBoard,
+      players: [],
+      currentPlayerIndex: 0,
+      phase: 'playing',
+    } as unknown as SerializableGameState;
+
+    hydrateSerializableState(fakeState);
+
+    // Verify the board stored in gameStore is a proper Board instance
+    const stored = (capturedState as { board: Board }).board;
+    expect(stored).toBeInstanceOf(Board);
+    expect(stored.cells).toBeInstanceOf(Map);
+
+    // Prototype methods must be callable
+    expect(() => stored.getPlayerSettlements(1)).not.toThrow();
+    expect(stored.getPlayerSettlements(1)).toHaveLength(1);
+    expect(() => stored.cells.entries()).not.toThrow();
+    expect(stored.getCell({ q: 2, r: 3 })?.settlement).toBe(1);
+  });
+
+  it('preserves all other state fields unchanged', () => {
+    const board = new Board(5, 5);
+    const serialised = serializeBoard(board);
+    const wireBoard = JSON.parse(JSON.stringify(serialised));
+
+    const fakeState = {
+      board: wireBoard,
+      currentPlayerIndex: 2,
+      phase: 'game_over',
+      players: [{ id: 1, name: 'Alice' }],
+    } as unknown as SerializableGameState;
+
+    hydrateSerializableState(fakeState);
+
+    const stored = capturedState as Record<string, unknown>;
+    expect(stored.currentPlayerIndex).toBe(2);
+    expect(stored.phase).toBe('game_over');
+    expect(stored.players).toEqual([{ id: 1, name: 'Alice' }]);
+  });
+
+  it('round-trips serialize → JSON wire → hydrateSerializableState → Board.getPlayerSettlements', () => {
+    const board = new Board(20, 20);
+    // Place settlements for two players
+    board.setCell({ coord: { q: 0, r: 0 }, terrain: Terrain.Grass, settlement: 1 });
+    board.setCell({ coord: { q: 1, r: 0 }, terrain: Terrain.Forest, settlement: 1 });
+    board.setCell({ coord: { q: 0, r: 1 }, terrain: Terrain.Desert, settlement: 2 });
+
+    const wireBoard = JSON.parse(JSON.stringify(serializeBoard(board)));
+    const fakeState = { board: wireBoard } as unknown as SerializableGameState;
+
+    hydrateSerializableState(fakeState);
+
+    const stored = (capturedState as { board: Board }).board;
+    expect(stored.getPlayerSettlements(1)).toHaveLength(2);
+    expect(stored.getPlayerSettlements(2)).toHaveLength(1);
+    expect(stored.getPlayerSettlements(3)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #181 — Host 按 Start Multiplayer Game 後雙方白屏。

### Root Cause

Two symmetrical bugs in `src/multiplayer/stateSerializer.ts`:

**Bug 1 — extractSerializableState (sender side)**
`Board.cells` is a `Map`. `JSON.stringify(Map)` produces `{}` (empty object), not an array. The entire board was being sent over the wire as `{ width, height, cells: {} }`, so guests received an empty board.

**Bug 2 — hydrateSerializableState (receiver side)**
Even if cells had arrived correctly, `useGameStore.setState(next)` with a plain-JSON board would leave `board` as a plain object — no `Board` prototype, no `getPlayerSettlements`, no `cells.entries`. This produced the observed TypeErrors:
- `TypeError: r.getPlayerSettlements is not a function`
- `TypeError: r.cells.entries is not a function`

### Fix

Reused the existing `serializeBoard` / `deserializeBoard` pair from `src/core/board.ts` — the same path already used by single-player localStorage persistence — so both ends of the multiplayer wire use the same serialisation contract.

- `extractSerializableState`: calls `serializeBoard(board)` before the state is sent, converting `Map` → `[key, HexCell][]` array.
- `hydrateSerializableState`: calls `deserializeBoard(boardData)` to reconstruct a proper `Board` instance before calling `setState`.

### Also fixed

Pre-existing TS2307 / TS7006 errors in `MultiplayerSetup.tsx` (introduced in PR #180) that were blocking the pre-push hook. Added `RoomPlayer` import and explicit parameter types on sort/find/map/every callbacks. No behaviour change.

## Changed files

- `src/multiplayer/stateSerializer.ts` — core fix (serialise on send, deserialise on receive)
- `src/components/Game/MultiplayerSetup.tsx` — pre-existing TS strict-mode fixes
- `src/test/stateSerializer.test.ts` — new (4 tests covering the round-trip)

## Test plan

- [x] `npm run build` (tsc -b + vite build) passes
- [x] `npx vitest run` — 660 tests pass
- [x] Playwright: Host + Guest both render canvas after Start Multiplayer Game (screenshots: /tmp/p0-mp-ingame-host.png, /tmp/p0-mp-ingame-guest.png)
- [x] Playwright: Host reload → reconnect → canvas still renders (/tmp/p0-mp-reconnect.png)
- [x] Playwright: Single player unaffected (/tmp/p0-single-ok.png)
- [x] No pageerror on either host or guest

🤖 Generated with [Claude Code](https://claude.com/claude-code)