### PR TITLE
fix(tutorial): spotlight pointer-events-none (#191)

### DIFF
--- a/src/components/Tutorial/TutorialOverlay.tsx
+++ b/src/components/Tutorial/TutorialOverlay.tsx
@@ -141,7 +141,7 @@ export function TutorialOverlay() {
         <div
           data-testid="tutorial-spotlight"
           aria-hidden="true"
-          className="fixed rounded-xl border-4 border-yellow-300 shadow-[0_0_0_9999px_rgba(0,0,0,0.5),0_0_24px_rgba(250,204,21,0.9)] transition-all duration-200 z-[60]"
+          className="fixed rounded-xl border-4 border-yellow-300 shadow-[0_0_0_9999px_rgba(0,0,0,0.5),0_0_24px_rgba(250,204,21,0.9)] transition-all duration-200 z-[60] pointer-events-none"
           style={spotlightRect}
         />
       )}

--- a/tests/e2e/tutorial.spec.ts
+++ b/tests/e2e/tutorial.spec.ts
@@ -18,7 +18,7 @@ test.beforeEach(async ({ page }) => {
 //
 // Evidence: test-results screenshot shows "tutorial-spotlight intercepts pointer events"
 // See https://github.com/cancleeric/kingdom-builder-web/issues/191
-test.skip('tutorial: highlighted draw card action advances the tutorial', async ({ page }) => {
+test('tutorial: highlighted draw card action advances the tutorial', async ({ page }) => {
   const setupPage = new SetupPage(page);
   const gamePage = new GamePage(page);
 


### PR DESCRIPTION
Closes #191. 一行修復：tutorial-spotlight overlay 加 pointer-events-none，highlighted 操作可點擊。e2e tutorial spec 已 unskip 轉綠（CEO 親跑）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)