### PR TITLE
chore: lint debt zero — closes #185

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Lint
         run: npm run lint
-        continue-on-error: true
 
       - name: Run tests with coverage
         run: npm run test:coverage

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'coverage']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [
@@ -18,6 +18,17 @@ export default defineConfig([
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+        },
+      ],
     },
   },
 ])

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,6 +81,7 @@ function usePrevious<T>(value: T): T | undefined {
   useEffect(() => {
     ref.current = value;
   });
+  // eslint-disable-next-line react-hooks/refs -- intentional: usePrevious reads stale ref during render (React docs pattern)
   return ref.current;
 }
 

--- a/src/components/Board/HexGrid.tsx
+++ b/src/components/Board/HexGrid.tsx
@@ -1,73 +1,14 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { Board } from '../../core/board';
-import { AxialCoord, hexEquals, HEX_SIZE, axialToPixel } from '../../core/hex';
+import { AxialCoord, hexEquals, HEX_SIZE } from '../../core/hex';
 import { HexCell } from './HexCell';
 import { TerrainDefs } from './TerrainDefs';
 import { PieceDefs } from './PieceDefs';
-import { Player, HexCell as HexCellData } from '../../types';
-import { useBoardTransform, Transform } from '../../hooks/useBoardTransform';
+import { Player } from '../../types';
+import { useBoardTransform } from '../../hooks/useBoardTransform';
 import { useTranslation } from 'react-i18next';
 import { useGameStore } from '../../store/gameStore';
-
-/**
- * Given a client-space coordinate (e.g. from mouse or touch event),
- * reverse the container transform and SVG viewBox scaling to find
- * which hex cell is at that point. Returns null if no cell is close enough.
- */
-export function findHexAtClientXY(
-  clientX: number,
-  clientY: number,
-  cells: HexCellData[],
-  transform: Transform,
-  containerRect: DOMRect,
-  svgElement: SVGSVGElement,
-  gridOffset: number,
-): AxialCoord | null {
-  // Step 1: position relative to container
-  const cx = clientX - containerRect.left;
-  const cy = clientY - containerRect.top;
-
-  // Step 2: undo transform (scale + translate)
-  const sx = (cx - transform.translateX) / transform.scale;
-  const sy = (cy - transform.translateY) / transform.scale;
-
-  // Step 3: SVG viewBox scaling
-  // The inner <div> is 100%×100% of container, SVG is also 100%×100% of that div
-  // We need the ratio between the rendered SVG size and its viewBox
-  const svgRect = svgElement.getBoundingClientRect();
-  const viewBox = svgElement.viewBox.baseVal;
-  const scaleX = svgRect.width > 0 ? viewBox.width / svgRect.width : 1;
-  const scaleY = svgRect.height > 0 ? viewBox.height / svgRect.height : 1;
-
-  // sx/sy are in the coordinate space of the inner div (which is 100%x100% of container)
-  // svgRect is also in client space, so we need to account for svgRect offset relative to container
-  const svgOffsetX = svgRect.left - containerRect.left;
-  const svgOffsetY = svgRect.top - containerRect.top;
-
-  const viewBoxX = (sx - svgOffsetX) * scaleX;
-  const viewBoxY = (sy - svgOffsetY) * scaleY;
-
-  // Step 4: subtract gridOffset to get hex coordinate space
-  const hexSpaceX = viewBoxX - gridOffset;
-  const hexSpaceY = viewBoxY - gridOffset;
-
-  // Step 5: find closest cell within HEX_SIZE * 0.95 threshold
-  let bestCell: HexCellData | null = null;
-  let bestDist = HEX_SIZE * 0.95;
-
-  for (const cell of cells) {
-    const center = axialToPixel(cell.coord, HEX_SIZE);
-    const dx = hexSpaceX - center.x;
-    const dy = hexSpaceY - center.y;
-    const dist = Math.sqrt(dx * dx + dy * dy);
-    if (dist < bestDist) {
-      bestDist = dist;
-      bestCell = cell;
-    }
-  }
-
-  return bestCell ? bestCell.coord : null;
-}
+import { findHexAtClientXY } from './hexGridUtils';
 
 interface HexGridProps {
   board: Board;
@@ -138,6 +79,7 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
 
   useEffect(() => {
     if (!invalidClickKey) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- UI-only: sync invalidClickKey to local flash state for one-shot animation
     setInvalidFlashKey(invalidClickKey);
     const timer = setTimeout(() => setInvalidFlashKey(null), 400);
     return () => clearTimeout(timer);
@@ -171,6 +113,7 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
     prevSettlementKeysRef.current = currentKeys;
 
     if (newKey) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- UI-only: sync newly-placed settlement key to local state for one-shot ring animation
       setRecentlyPlacedKey(newKey);
       const timer = setTimeout(() => setRecentlyPlacedKey(null), 350);
       return () => clearTimeout(timer);
@@ -260,7 +203,7 @@ export const HexGrid: React.FC<HexGridProps> = React.memo(({
         }
       }
     },
-    [board, validPlacements, onCellClick, onEscape, focusHex],
+    [board, validPlacements, onCellClick, onEscape, focusHex, editable, onEditCellClick],
   );
 
   // Determine the single entry-point cell that gets tabIndex=0 (roving tabindex pattern)

--- a/src/components/Board/hexGridUtils.ts
+++ b/src/components/Board/hexGridUtils.ts
@@ -1,0 +1,63 @@
+import { AxialCoord, HEX_SIZE, axialToPixel } from '../../core/hex';
+import { HexCell as HexCellData } from '../../types';
+import { Transform } from '../../hooks/useBoardTransform';
+
+/**
+ * Given a client-space coordinate (e.g. from mouse or touch event),
+ * reverse the container transform and SVG viewBox scaling to find
+ * which hex cell is at that point. Returns null if no cell is close enough.
+ */
+export function findHexAtClientXY(
+  clientX: number,
+  clientY: number,
+  cells: HexCellData[],
+  transform: Transform,
+  containerRect: DOMRect,
+  svgElement: SVGSVGElement,
+  gridOffset: number,
+): AxialCoord | null {
+  // Step 1: position relative to container
+  const cx = clientX - containerRect.left;
+  const cy = clientY - containerRect.top;
+
+  // Step 2: undo transform (scale + translate)
+  const sx = (cx - transform.translateX) / transform.scale;
+  const sy = (cy - transform.translateY) / transform.scale;
+
+  // Step 3: SVG viewBox scaling
+  // The inner <div> is 100%×100% of container, SVG is also 100%×100% of that div
+  // We need the ratio between the rendered SVG size and its viewBox
+  const svgRect = svgElement.getBoundingClientRect();
+  const viewBox = svgElement.viewBox.baseVal;
+  const scaleX = svgRect.width > 0 ? viewBox.width / svgRect.width : 1;
+  const scaleY = svgRect.height > 0 ? viewBox.height / svgRect.height : 1;
+
+  // sx/sy are in the coordinate space of the inner div (which is 100%x100% of container)
+  // svgRect is also in client space, so we need to account for svgRect offset relative to container
+  const svgOffsetX = svgRect.left - containerRect.left;
+  const svgOffsetY = svgRect.top - containerRect.top;
+
+  const viewBoxX = (sx - svgOffsetX) * scaleX;
+  const viewBoxY = (sy - svgOffsetY) * scaleY;
+
+  // Step 4: subtract gridOffset to get hex coordinate space
+  const hexSpaceX = viewBoxX - gridOffset;
+  const hexSpaceY = viewBoxY - gridOffset;
+
+  // Step 5: find closest cell within HEX_SIZE * 0.95 threshold
+  let bestCell: HexCellData | null = null;
+  let bestDist = HEX_SIZE * 0.95;
+
+  for (const cell of cells) {
+    const center = axialToPixel(cell.coord, HEX_SIZE);
+    const dx = hexSpaceX - center.x;
+    const dy = hexSpaceY - center.y;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestCell = cell;
+    }
+  }
+
+  return bestCell ? bestCell.coord : null;
+}

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -27,6 +27,7 @@ export function useModal({ isOpen, onClose, disableEscClose = false }: UseModalO
   const panelRef = useRef<HTMLDivElement>(null);
   // Stable reference so event listener can always call the latest onClose
   const onCloseRef = useRef(onClose);
+  // eslint-disable-next-line react-hooks/refs -- intentional: stable-ref pattern to capture latest callback without re-subscribing
   onCloseRef.current = onClose;
 
   // ESC key handler

--- a/src/mapEditor/codec.test.ts
+++ b/src/mapEditor/codec.test.ts
@@ -91,7 +91,7 @@ describe('decode — security guards', () => {
   });
 
   it('invalid terrain → null', () => {
-    const bad: any = {
+    const bad: Record<string, unknown> = {
       v: 1,
       w: 12,
       h: 12,
@@ -105,7 +105,7 @@ describe('decode — security guards', () => {
   });
 
   it('invalid location → null', () => {
-    const bad: any = {
+    const bad: Record<string, unknown> = {
       v: 1,
       w: 12,
       h: 12,
@@ -119,7 +119,7 @@ describe('decode — security guards', () => {
   });
 
   it('cells not array → null', () => {
-    const bad: any = { v: 1, w: 12, h: 12, cells: 'not-array' };
+    const bad: Record<string, unknown> = { v: 1, w: 12, h: 12, cells: 'not-array' };
     const json = JSON.stringify(bad);
     const bytes = new TextEncoder().encode(json);
     const binary = String.fromCharCode(...bytes);
@@ -128,7 +128,7 @@ describe('decode — security guards', () => {
   });
 
   it('null as any → null (no throw)', () => {
-    expect(() => decode(null as any)).not.toThrow();
-    expect(decode(null as any)).toBeNull();
+    expect(() => decode(null as unknown as string)).not.toThrow();
+    expect(decode(null as unknown as string)).toBeNull();
   });
 });

--- a/src/mapEditor/devExpose.ts
+++ b/src/mapEditor/devExpose.ts
@@ -2,5 +2,9 @@ import { encode, decode } from './codec';
 import { useCustomMapStore } from './customMapStore';
 
 if (import.meta.env.DEV) {
-  (window as any).__KB__ = { encode, decode, store: () => useCustomMapStore.getState() };
+  (window as typeof window & { __KB__: unknown }).__KB__ = {
+    encode,
+    decode,
+    store: () => useCustomMapStore.getState(),
+  };
 }

--- a/tests/e2e/multiplayer-platform.spec.ts
+++ b/tests/e2e/multiplayer-platform.spec.ts
@@ -21,7 +21,8 @@
 
 import { test, expect } from '@playwright/test';
 
-const WS_URL = 'ws://localhost:8787';
+// WS_URL kept for documentation; actual connection is managed by the server under test
+const _WS_URL = 'ws://localhost:8787';
 
 // Helper: suppress known non-critical console noise (missing assets, etc.)
 function isNonCriticalError(msg: string): boolean {

--- a/tests/e2e/r29-bot-screenshot.spec.ts
+++ b/tests/e2e/r29-bot-screenshot.spec.ts
@@ -6,7 +6,8 @@ import { test, expect } from '@playwright/test';
 import { SetupPage } from '../pages/SetupPage';
 import { GamePage } from '../pages/GamePage';
 
-const BASE = 'http://localhost:5174';
+// BASE was hardcoded for manual dev; Playwright webServer config uses port 5173
+const _BASE = 'http://localhost:5174';
 
 test.beforeEach(async ({ page }) => {
   await page.addInitScript(() => {
@@ -29,11 +30,11 @@ test('R29: screenshot TurnBanner bot indicator', async ({ page }) => {
   // Set bot turn active via setState so we can screenshot
   await page.evaluate(async () => {
     const { useGameStore } = await import('/src/store/gameStore.ts');
-    const state = useGameStore.getState();
+    const { GamePhase } = await import('/src/types/index.ts');
     // Switch to player 2 (bot) in DrawCard phase
     useGameStore.setState({
       currentPlayerIndex: 1,
-      phase: 'DrawCard' as any,
+      phase: GamePhase.DrawCard,
     });
   });
 

--- a/tests/e2e/r29-bot-turn-observe.spec.ts
+++ b/tests/e2e/r29-bot-turn-observe.spec.ts
@@ -111,6 +111,7 @@ test.skip('R29: bot turn timing and banner indicator', async ({ page }) => {
       so.observe(svg, { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] });
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only debug property on window
     (window as any).__r29log = log;
   });
 
@@ -128,6 +129,7 @@ test.skip('R29: bot turn timing and banner indicator', async ({ page }) => {
 
   // Mark time before ending turn
   await page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only debug property on window
     (window as any).__r29turnEndAt = Date.now();
     console.log('[R29] Player 1 ending turn...');
   });
@@ -144,7 +146,7 @@ test.skip('R29: bot turn timing and banner indicator', async ({ page }) => {
       b => b.textContent?.includes('End Turn')
     );
     if (byText) { byText.click(); return; }
-    // Fallback: useGameStore via window
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only fallback via window globals
     const store = (window as any).__zustand_store ?? (window as any).useGameStore;
     if (store) store.getState().endTurn();
   });
@@ -173,9 +175,10 @@ test.skip('R29: bot turn timing and banner indicator', async ({ page }) => {
   await page.screenshot({ path: 'test-results/r29-after-bot.png' });
 
   // ── 4. Collect and analyze log ──────────────────────────────────────────
-  const events = await page.evaluate(() =>
-    (window as any).__r29log as Array<{ time: number; event: string }>
-  );
+  const events = await page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only debug property on window
+    return (window as any).__r29log as Array<{ time: number; event: string }>;
+  });
 
   console.log('\n=== R29 Observer Log ===');
   for (const e of events) {

--- a/tests/e2e/r30-invalid-feedback.spec.ts
+++ b/tests/e2e/r30-invalid-feedback.spec.ts
@@ -33,7 +33,7 @@ test.describe.skip('R30 invalid placement visual feedback', () => {
     const { shakeDetected, hintToastText } = await page.evaluate(async () => {
       return new Promise<{ shakeDetected: boolean; hintToastText: string }>((resolve) => {
         let shakeFound = false;
-        const deadline = setTimeout(() => {
+        setTimeout(() => {
           observer.disconnect();
           // Check for hint toast text at timeout
           const statuses = document.querySelectorAll('[role="status"][aria-live="polite"]');


### PR DESCRIPTION
## Summary

- Clears all 35 pre-existing ESLint errors to 0 (closes #185)
- Removes `continue-on-error: true` from CI Lint step so lint failures now block CI

## Changes

| 類別 | 檔案 | 做法 |
|------|------|------|
| react-refresh/only-export-components | `HexGrid.tsx` | 將 `findHexAtClientXY` 抽到新檔 `hexGridUtils.ts`，HexGrid.tsx 改內部 import |
| react-compiler / exhaustive-deps | `HexGrid.tsx` | `handleKeyDown` deps 補 `editable`, `onEditCellClick`（修正 stale closure） |
| react-hooks/set-state-in-effect x2 | `HexGrid.tsx` | inline disable + 說明（UI-only one-shot animation，無法用 useEffectEvent） |
| react-hooks/refs x2 | `App.tsx`, `useModal.ts` | inline disable + 說明（usePrevious 官方 pattern；stable-ref pattern） |
| no-explicit-any x12 | `codec.test.ts`, `devExpose.ts`, `r29-bot-screenshot.spec.ts`, `r29-bot-turn-observe.spec.ts` | 補具體型別或 inline disable（page.evaluate 內 window 存取） |
| no-unused-vars x6 | persistence tests, e2e specs | eslint config 加 `varsIgnorePattern/destructuredArrayIgnorePattern: '^_'`；test 常數改 `_` 前綴 |
| eslint config | `eslint.config.js` | 忽略 `coverage/`，加完整 unused-vars ignore patterns |

## Inline disable 計數：5 處

1. `HexGrid.tsx` set-state-in-effect #1 — UI-only invalidClickKey→flash sync
2. `HexGrid.tsx` set-state-in-effect #2 — UI-only settlement ring sync
3. `App.tsx` react-hooks/refs — usePrevious 官方 stale-ref pattern
4. `useModal.ts` react-hooks/refs — stable-ref pattern for latest callback
5. `r29-bot-turn-observe.spec.ts` no-explicit-any x4 — page.evaluate browser context window globals（全在 test.skip 區塊）

## Test results

- `npm run lint`: 0 errors (12 warnings, not in scope)
- `npm run build`: pass
- `npm run test:coverage`: 786/786 pass
- `npm run test:e2e -- --project=chromium`: 56 pass / 9 skip / 0 fail
- `npm run qa:smoke`: 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)