### PR TITLE
feat: upgrade More Games portal to 3 real-link cards with Evolution

### DIFF
--- a/src/components/Menu/MainMenu.tsx
+++ b/src/components/Menu/MainMenu.tsx
@@ -344,11 +344,20 @@ export function MainMenu({
           >
             {t('menu.otherGames')}
           </p>
-          <div className="w-full flex gap-3">
+          <div
+            className="w-full"
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(3, 1fr)',
+              gap: '0.5rem',
+            }}
+          >
             {/* Gress Herbalism */}
             <a
-              href="#herbalism"
-              className="flex-1 flex flex-col items-center gap-1 py-3 px-2 rounded-14 transition"
+              href={import.meta.env.VITE_URL_HERBALISM ?? 'http://192.168.50.83:8085/lobby/herbalism'}
+              target="_blank"
+              rel="noopener"
+              className="flex flex-col items-center gap-1 py-3 px-2 rounded-14 transition"
               style={{
                 backgroundColor: 'var(--color-warm-cream-200)',
                 border: '1px solid var(--card-border)',
@@ -365,17 +374,48 @@ export function MainMenu({
               }}
             >
               <span style={{ fontSize: '1.25rem', lineHeight: 1 }} aria-hidden="true">🌿</span>
-              <span className="font-body font-semibold" style={{ fontSize: 'var(--type-body-sm)' }}>
+              <span className="font-body font-semibold" style={{ fontSize: 'var(--type-body-sm)', textAlign: 'center' }}>
                 {t('menu.herbalism')}
               </span>
-              <span className="font-body" style={{ fontSize: 'var(--type-label)', color: 'var(--color-stone-500)' }}>
+              <span className="font-body" style={{ fontSize: 'var(--type-label)', color: 'var(--color-stone-500)', textAlign: 'center' }}>
                 {t('menu.herbalismDesc')}
+              </span>
+            </a>
+            {/* Evolution */}
+            <a
+              href={import.meta.env.VITE_URL_EVOLUTION ?? 'http://192.168.50.83:8085/lobby/evolution'}
+              target="_blank"
+              rel="noopener"
+              className="flex flex-col items-center gap-1 py-3 px-2 rounded-14 transition"
+              style={{
+                backgroundColor: 'var(--color-warm-cream-200)',
+                border: '1px solid var(--card-border)',
+                color: 'var(--color-stone-700)',
+                textDecoration: 'none',
+              }}
+              onMouseEnter={(e) => {
+                (e.currentTarget as HTMLAnchorElement).style.backgroundColor = 'var(--color-warm-cream-300)';
+                (e.currentTarget as HTMLAnchorElement).style.borderColor = 'var(--color-wine-400)';
+              }}
+              onMouseLeave={(e) => {
+                (e.currentTarget as HTMLAnchorElement).style.backgroundColor = 'var(--color-warm-cream-200)';
+                (e.currentTarget as HTMLAnchorElement).style.borderColor = 'var(--card-border)';
+              }}
+            >
+              <span style={{ fontSize: '1.25rem', lineHeight: 1 }} aria-hidden="true">🧬</span>
+              <span className="font-body font-semibold" style={{ fontSize: 'var(--type-body-sm)', textAlign: 'center' }}>
+                {t('menu.evolution')}
+              </span>
+              <span className="font-body" style={{ fontSize: 'var(--type-label)', color: 'var(--color-stone-500)', textAlign: 'center' }}>
+                {t('menu.evolutionDesc')}
               </span>
             </a>
             {/* Sudoku */}
             <a
-              href="#sudoku"
-              className="flex-1 flex flex-col items-center gap-1 py-3 px-2 rounded-14 transition"
+              href={import.meta.env.VITE_URL_SUDOKU ?? 'http://192.168.50.83:8089/'}
+              target="_blank"
+              rel="noopener"
+              className="flex flex-col items-center gap-1 py-3 px-2 rounded-14 transition"
               style={{
                 backgroundColor: 'var(--color-warm-cream-200)',
                 border: '1px solid var(--card-border)',
@@ -392,10 +432,10 @@ export function MainMenu({
               }}
             >
               <span style={{ fontSize: '1.25rem', lineHeight: 1 }} aria-hidden="true">🔢</span>
-              <span className="font-body font-semibold" style={{ fontSize: 'var(--type-body-sm)' }}>
+              <span className="font-body font-semibold" style={{ fontSize: 'var(--type-body-sm)', textAlign: 'center' }}>
                 {t('menu.sudoku')}
               </span>
-              <span className="font-body" style={{ fontSize: 'var(--type-label)', color: 'var(--color-stone-500)' }}>
+              <span className="font-body" style={{ fontSize: 'var(--type-label)', color: 'var(--color-stone-500)', textAlign: 'center' }}>
                 {t('menu.sudokuDesc')}
               </span>
             </a>

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -90,6 +90,8 @@ export const en = {
     otherGames: 'More Games',
     herbalism: 'Gress Herbalism',
     herbalismDesc: 'Herbal Board Game',
+    evolution: 'Evolution',
+    evolutionDesc: 'Biology Evolution Board Game',
     sudoku: 'Sudoku',
     sudokuDesc: 'Number Puzzle',
   },

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -90,6 +90,8 @@ export const zhTW = {
     otherGames: '更多遊戲',
     herbalism: '本草棋遊',
     herbalismDesc: '中草藥桌遊',
+    evolution: '演化論',
+    evolutionDesc: '生物演化桌遊',
     sudoku: '數獨',
     sudokuDesc: '數字謎題',
   },

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_URL_HERBALISM: string | undefined;
+  readonly VITE_URL_EVOLUTION: string | undefined;
+  readonly VITE_URL_SUDOKU: string | undefined;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary

- Add **Evolution** card (🧬) as the missing 3rd game in the More Games portal
- Replace placeholder `#herbalism` / `#sudoku` hrefs with real URLs driven by `VITE_URL_HERBALISM` / `VITE_URL_EVOLUTION` / `VITE_URL_SUDOKU` env vars (default to `192.168.50.83` dev servers)
- All three cards now use `target="_blank" rel="noopener"` so clicking opens a new tab without killing the current game session
- Switch portal layout from `flex` 2-col to CSS `grid` 3-col so all three cards fit cleanly at 375px mobile width
- i18n: add `evolution` / `evolutionDesc` keys in both `en` and `zh-TW`
- Add `src/vite-env.d.ts` declaring `VITE_URL_*` env types

## Test plan

- [x] `npm run build` (tsc -b + vite build) — clean
- [x] `npx vitest run` — 786/786 passed
- [x] pre-push hook — passed on push
- [x] Playwright desktop 1440 screenshot — 3 cards visible (`/tmp/portal3-desktop.png`)
- [x] Playwright mobile 375 screenshot — 3 cards fit without overflow (`/tmp/portal3-mobile.png`)
- [x] Evolution href verified: `http://192.168.50.83:8085/lobby/evolution`
- [x] All 3 hrefs use `target="_blank"`, Evolution card opens correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)