### PR TITLE
feat(docker): 前端 serve 從 vite preview 改為 nginx:1.27-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,8 @@ ARG VITE_URL_SUDOKU=http://192.168.50.83:8089/
 ENV VITE_URL_SUDOKU=$VITE_URL_SUDOKU
 RUN npm run build
 
-FROM node:22-alpine AS runtime
-WORKDIR /app
-COPY --from=build /app/node_modules ./node_modules
-COPY --from=build /app/package.json ./package.json
-COPY --from=build /app/dist ./dist
-COPY --from=build /app/server ./server
-COPY --from=build /app/vite.config.ts ./vite.config.ts
-COPY --from=build /app/tsconfig*.json ./
-EXPOSE 4173 8787
-CMD ["npx", "vite", "preview", "--host", "0.0.0.0", "--port", "4173"]
+FROM nginx:1.27-alpine AS runtime
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,8 @@ services:
         VITE_WS_SERVER_URL: ws://localhost:8088
     image: kingdom-builder-web:dev
     container_name: kingdom-frontend-dev
-    command: ["npx", "vite", "preview", "--host", "0.0.0.0", "--port", "4173"]
     ports:
-      - "8087:4173"
+      - "8087:80"
     restart: unless-stopped
 
   kingdom-ws-dev:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,47 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Service worker: no-store（避免 PWA 更新後卡舊 SW）
+    location = /service-worker.js {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+        add_header Pragma "no-cache";
+        expires 0;
+    }
+
+    # index.html: no-cache（每次走 ETag 驗新，SPA entry 不走舊快取）
+    location = /index.html {
+        add_header Cache-Control "no-cache, must-revalidate";
+        expires 0;
+    }
+
+    # manifest.json: no-cache
+    location = /manifest.json {
+        add_header Cache-Control "no-cache, must-revalidate";
+        expires 0;
+    }
+
+    # Vite hash 靜態資源（JS / CSS / 圖片）: 長快取
+    location ~* \.(?:js|css|woff2?|ttf|eot|png|jpg|jpeg|gif|svg|ico|webp)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # 安全標頭
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # Gzip
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml application/javascript application/json application/xml+rss image/svg+xml;
+}


### PR DESCRIPTION
## 改了什麼

### 問題
舊 Dockerfile runtime stage 用 `node:22-alpine` + `npx vite preview`，這是開發工具，不適合生產使用（無安全標頭、無適當快取策略、image 肥大包含 node_modules）。

### 解法

**Dockerfile**
- build stage（`node:22-alpine`）：完全不動，保留所有 `VITE_*` ARG/ENV 接線
- runtime stage：從 `node:22-alpine + vite preview` 換為 `nginx:1.27-alpine`
  - image 大幅縮小（不帶 node_modules / vite.config.ts / tsconfig*.json）

**新增 nginx.conf**（PWA 快取策略）

| 路徑 | Cache-Control | 原因 |
|------|--------------|------|
| `/service-worker.js` | `no-store` | SW 升級後必須每次拉新版，否則用戶卡舊版 |
| `/index.html` | `no-cache` | SPA entry point，走 ETag 驗新 |
| `/manifest.json` | `no-cache` | PWA manifest 同上 |
| `/assets/*` (hash 檔名) | `1y immutable` | Vite hash bundle 永久快取安全 |

**docker-compose.yml**（最小改動）
- `kingdom-frontend-dev` port mapping: `8087:4173` → `8087:80`（nginx 預設 80）
- 移除顯式 `command` 覆寫（改由 Dockerfile CMD 的 nginx 預設執行）
- `kingdom-ws-dev`（WS server / port 8787/8088 / `node server/index.js`）**完全未動**

### WS server 接線確認
WS server 獨立跑在 `kingdom-ws-dev` container，透過 docker-compose `depends_on` 依附，port 8787/8088 不變。前端透過 `VITE_WS_SERVER_URL`（build ARG）指向 WS server，此變數在 build stage 烤入 JS，與 nginx serve 層無關。

## 自測結果

本機 `npm run build`（驗證 build stage 指令）：

```
> tsc -b && vite build
vite v7.3.3 building client environment for production...
✓ 905 modules transformed.
dist/index.html   0.97 kB
dist/assets/...   (hash 檔名確認)
✓ built in 1.96s
```

`dist/` 確認包含 `index.html`、`service-worker.js`、`manifest.json`、`icons/`、`assets/`，nginx.conf location 路徑對齊。

pre-push hook 輸出（build + vitest 全套）：
```
Test Files  42 passed (42)
    Tests  786 passed (786)
```

Dockerfile 本體未在本機實際 `docker build`（本機不跑 docker），語法已人工 review，等 CEO 在 .199 上驗證實際 build。

## 不確定項目
- 無。WS server 接線未動，只改前端 serve 層，範圍明確。

🤖 Generated with [Claude Code](https://claude.com/claude-code)