### PR TITLE
fix(auth): PR-2 — kingdom 共享 session issuer fallback 對齊 portal + 明確未登入提示

### DIFF
--- a/src/auth/LidsBadge.tsx
+++ b/src/auth/LidsBadge.tsx
@@ -15,8 +15,14 @@ interface LidsBadgeProps {
   variant?: 'header' | 'menu'
 }
 
+// 大廳（hd-portal）入口。共享 session 讀不到時，引導玩家回大廳登入。
+const LOBBY_URL = 'https://192.168.50.199:8443/'
+
 export function LidsBadge({ variant = 'header' }: LidsBadgeProps) {
-  const { user, clearSession } = useLidsSession()
+  const { loading, user, clearSession } = useLidsSession()
+
+  // 仍在讀取共享 session，先不顯示未登入提示避免閃爍誤判
+  if (loading) return null
 
   if (variant === 'menu') {
     if (user) {
@@ -46,17 +52,19 @@ export function LidsBadge({ variant = 'header' }: LidsBadgeProps) {
     }
     return (
       <a
-        href="https://192.168.50.199:8443/"
-        className="hidden sm:inline-block text-xs px-2 py-1 rounded opacity-60 hover:opacity-90 transition"
+        href={LOBBY_URL}
+        className="hidden sm:inline-flex items-center gap-1 text-xs px-2 py-1 rounded hover:opacity-90 transition"
         style={{
           backgroundColor: 'var(--color-warm-cream-300)',
-          color: 'var(--color-stone-600)',
+          color: 'var(--color-stone-700)',
           border: '1px solid var(--card-border)',
           textDecoration: 'none',
         }}
-        title="Go to portal to sign in"
+        title="回大廳登入"
+        aria-label="尚未登入，請先在大廳登入"
       >
-        未登入
+        <span aria-hidden="true">⤺</span>
+        請先在大廳登入
       </a>
     )
   }
@@ -85,16 +93,18 @@ export function LidsBadge({ variant = 'header' }: LidsBadgeProps) {
   }
   return (
     <a
-      href="https://192.168.50.199:8443/"
-      className="hidden sm:inline-block text-xs px-2 py-1 rounded opacity-60 hover:opacity-90 transition"
+      href={LOBBY_URL}
+      className="hidden sm:inline-flex items-center gap-1 text-xs px-2 py-1 rounded hover:opacity-90 transition"
       style={{
         backgroundColor: 'oklch(0 0 0 / 0.2)',
         color: 'var(--color-warm-cream-50)',
         textDecoration: 'none',
       }}
-      title="Go to portal to sign in"
+      title="回大廳登入"
+      aria-label="尚未登入，請先在大廳登入"
     >
-      未登入
+      <span aria-hidden="true">⤺</span>
+      請先在大廳登入
     </a>
   )
 }

--- a/src/auth/lidsSession.test.ts
+++ b/src/auth/lidsSession.test.ts
@@ -5,7 +5,9 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { getSharedLidsUser, clearSharedLidsSession } from './lidsSession'
 
-const OIDC_KEY = 'oidc.user:http://192.168.50.199:8073:hd-portal-199'
+// 測試在 vitest（無 VITE_LIDS_* env 注入）下執行 → 被測程式碼走 fallback：
+// issuer=http://localhost:8073、client_id=hd-portal-dev（對齊 portal lids-adapter.ts）
+const OIDC_KEY = 'oidc.user:http://localhost:8073:hd-portal-dev'
 
 function makeEntry(overrides: Record<string, unknown> = {}): string {
   return JSON.stringify({
@@ -95,6 +97,26 @@ describe('getSharedLidsUser', () => {
 
   it('invalid JSON → returns null (no throw)', async () => {
     window.sessionStorage.setItem(OIDC_KEY, 'not-valid-json{{{')
+    const result = await getSharedLidsUser()
+    expect(result).toBeNull()
+  })
+
+  // 回歸護欄：fallback key 必須與 portal lids-adapter.ts fallback 對得上。
+  // 若有人把 issuer/client_id fallback 改回與 portal 不一致的字面（如舊的
+  // 192.168.50.199:8073 / hd-portal-199），portal 寫入的 entry 將讀不到。
+  it('reads the portal-aligned fallback key (no env) → returns profile', async () => {
+    // portal lids-adapter.ts dev fallback 寫入的 key
+    const portalFallbackKey = 'oidc.user:http://localhost:8073:hd-portal-dev'
+    window.sessionStorage.setItem(portalFallbackKey, makeEntry())
+    const result = await getSharedLidsUser()
+    expect(result).not.toBeNull()
+    expect(result?.sub).toBe('user-sub-001')
+  })
+
+  it('entry under the OLD mismatched key (192.168.50.199 / hd-portal-199) → NOT read', async () => {
+    // 證明 fallback 已不再用舊的不一致字面：舊 key 下的 entry 必須讀不到
+    const oldMismatchedKey = 'oidc.user:http://192.168.50.199:8073:hd-portal-199'
+    window.sessionStorage.setItem(oldMismatchedKey, makeEntry())
     const result = await getSharedLidsUser()
     expect(result).toBeNull()
   })

--- a/src/auth/lidsSession.ts
+++ b/src/auth/lidsSession.ts
@@ -9,19 +9,27 @@
  * ⚠️ authority + client_id 必須與 portal lids-adapter.ts 完全一致，
  *    才能對上 sessionStorage key：
  *    `oidc.user:${authority}:${client_id}`
- *    = `oidc.user:http://192.168.50.199:8073:hd-portal-199`
+ *
+ *    真值（.env.production，prod/.199 部署實際採用）：
+ *    portal 與 kingdom 皆 VITE_LIDS_ISSUER=http://localhost:8073、
+ *    VITE_LIDS_CLIENT_ID=hd-portal-199
+ *    → `oidc.user:http://localhost:8073:hd-portal-199`
+ *
+ *    fallback（無 env 的 dev 情境）：對齊 portal lids-adapter.ts（dev placeholder）
+ *    issuer=http://localhost:8073、client_id=hd-portal-dev，
+ *    讓 portal 寫入 / kingdom 讀取的 key 在無 env 時也對得上。
  *
  * ⛔ 不含 client_secret（Public PKCE client）
  */
 
-// ── env 讀取（與 portal .env.production 一致） ─────────────────────────────
+// ── env 讀取（與 portal lids-adapter.ts fallback 一致） ────────────────────
 const LIDS_ISSUER =
   (import.meta.env.VITE_LIDS_ISSUER as string | undefined) ??
-  'http://192.168.50.199:8073'
+  'http://localhost:8073'
 
 const LIDS_CLIENT_ID =
   (import.meta.env.VITE_LIDS_CLIENT_ID as string | undefined) ??
-  'hd-portal-199'
+  'hd-portal-dev'
 
 export interface LidsUserProfile {
   sub: string


### PR DESCRIPTION
## 對應 PR-2（HD 遊戲平台 Round 1 計劃）

打通「一次登入 → 點進 kingdom 不掉登入態」的第二道破口：kingdom 讀取共享 LIDS session 的 sessionStorage key fallback 與 portal 不一致，無 env 時必讀不到。

## ⚠️ 安全敏感 → 需 harper(CISO) + gray 雙審

本 PR 觸及 auth session 讀取。審查重點與本 PR 的保證：
- ✅ **維持唯讀**：只 `sessionStorage.getItem`，無新增 `setItem`/`fetch`/OIDC 請求/`UserManager` 呼叫。
- ✅ **不引入 secret**：無 `client_secret`（Public PKCE client）。
- ✅ **不放寬過期**：`expires_at` 過期檢查（`lidsSession.ts` 原第 59 行、現第 67 行）原封不動。
- ✅ 只改白名單 4 檔中的 3 檔（`useLidsSession.ts` 無需改）；未碰 `server/index.js`、`src/multiplayer/*`、任何 `.env*` 真值。

## 改了什麼

1. **`lidsSession.ts`** — fallback 由 `http://192.168.50.199:8073` / `hd-portal-199` 對齊到 portal `lids-adapter.ts` 的 dev placeholder `http://localhost:8073` / `hd-portal-dev`。讓「無 env」的 dev 情境，portal 寫入 / kingdom 讀取的 key 也對得上。
2. **`LidsBadge.tsx`** — 未登入時把隱晦的「未登入」小字改為明確「請先在大廳登入」+ 回大廳連結（header / menu 兩 variant）；session 讀取 loading 期間不顯示提示，避免閃爍誤判。
3. **`lidsSession.test.ts`** — `OIDC_KEY` 更新為對齊後的 fallback key；新增 2 個回歸護欄（portal fallback key 可讀；舊不一致 key 不可讀）。

## key 端到端對照（證明會對上）

| 情境 | issuer | client_id | sessionStorage key |
|------|--------|-----------|--------------------|
| **prod 真值**（兩邊 `.env.production` 注入） | `http://localhost:8073` | `hd-portal-199` | `oidc.user:http://localhost:8073:hd-portal-199` |
| **dev fallback**（無 env，本 PR 對齊後） | `http://localhost:8073` | `hd-portal-dev` | `oidc.user:http://localhost:8073:hd-portal-dev` |

兩情境下 portal 寫入 key 與 kingdom 讀取 key 字面完全一致。

## .env.production 注入查證（雙審判斷「不會破壞 .199 部署」依據）

親查兩 repo `.env.production`：
- kingdom `.env.production`: `VITE_LIDS_ISSUER=http://localhost:8073`、`VITE_LIDS_CLIENT_ID=hd-portal-199`
- portal `.env.production`: `VITE_LIDS_ISSUER=http://localhost:8073`、`VITE_LIDS_CLIENT_ID=hd-portal-199`

→ **prod/.199 build 兩邊真值已完全一致，fallback 在 prod 完全不被觸發**。本 PR 只改 fallback，**不影響 .199 部署**（prod key 不變）。**無任何部署依賴舊 fallback**（舊 fallback `192.168.50.199:8073`/`hd-portal-199` 在 prod 也不會被命中，因 env 已注入）。

## 驗證證據

- `npx vitest run`：44 files / 840 tests 全綠（含新增 2 護欄）。
- `npm run build`：成功（pixi chunk size 警告為既有，非本 PR 引入）。
- `git diff --name-only`：僅 `src/auth/{lidsSession.ts, lidsSession.test.ts, LidsBadge.tsx}`。

## ⛔ DO NOT MERGE — 待 CEO + 雙審（harper CISO + gray）+ eye 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)