### PR TITLE
feat(engine): R5 Phase1 PR-A — KingdomG pure domain type

### DIFF
--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @hd/kingdom-engine — barrel export for the Kingdom Builder engine adapter.
+ *
+ * PR-A: type definitions only.
+ * PR-B will add: kingdomGame (GameDefinition<KingdomG>), move functions.
+ * PR-C will add: test utilities / fixtures re-exported for tests.
+ */
+
+export type { KingdomG, ClientOnlyState } from './types';

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -1,0 +1,114 @@
+/**
+ * KingdomG — pure game-domain state for the Kingdom Builder engine adapter.
+ *
+ * Derived from SerializableGameState (src/store/persistence.ts) with UI-only
+ * fields removed:
+ *   - selectedCell      : UI cursor selection, not a game rule concern
+ *   - validPlacements   : derived/cached from getValidPlacements(), not ground truth
+ *   - history           : GameAction[] action log, used only for UI replay / recording
+ *
+ * All types are imported from the existing src/ type definitions; no new types
+ * are introduced here.
+ */
+
+import { Board } from '../core/board';
+import { TerrainCard, Location } from '../core/terrain';
+import { ObjectiveCard } from '../core/scoring';
+import { AxialCoord } from '../core/hex';
+import { Player, GamePhase, PlayerScore, GameOptions } from '../types';
+import { UndoSnapshot } from '../types/history';
+
+export interface KingdomG {
+  /** The hex grid (Board class with Map<string, HexCell> cells). */
+  board: Board;
+
+  /** All players in turn order. */
+  players: Player[];
+
+  /** Index into players[] for whose turn it currently is (0-based). */
+  currentPlayerIndex: number;
+
+  /**
+   * Current game phase.
+   * Valid engine states: DrawCard | PlaceSettlements | EndTurn | GameOver.
+   * Setup is a pre-game phase handled outside the engine.
+   */
+  phase: GamePhase;
+
+  /** The terrain card drawn for this turn; null during DrawCard phase. */
+  currentTerrainCard: TerrainCard | null;
+
+  /**
+   * How many settlement placements remain in the current PlaceSettlements
+   * phase (starts at 3 per turn, decrements on each valid placement).
+   */
+  remainingPlacements: number;
+
+  /** The remaining terrain draw deck. */
+  deck: TerrainCard[];
+
+  /**
+   * Keys of Location tiles that have been acquired (as "<q>,<r>" strings).
+   * Used to guard against re-awarding the same location tile.
+   */
+  acquiredLocations: string[];
+
+  /** The three objective cards in play for this game. */
+  objectiveCards: ObjectiveCard[];
+
+  /** Final per-player score breakdown; populated when phase === GameOver. */
+  finalScores: PlayerScore[];
+
+  /**
+   * Coordinates of settlements placed during the current turn.
+   * Required for the adjacency rule: 2nd and 3rd placements must be
+   * adjacent to a cell already placed this turn (when adjacent cells exist).
+   */
+  placementsThisTurn: AxialCoord[];
+
+  /** The Location tile currently being activated (null if none). */
+  activeTile: Location | null;
+
+  /**
+   * Valid source coordinates when executing a tile-move action
+   * (e.g. Paddock, Barn).
+   */
+  tileMoveSources: AxialCoord[];
+
+  /** The settlement coordinate chosen as the source of a tile move. */
+  tileMoveFrom: AxialCoord | null;
+
+  /** Valid destination coordinates for the current tile move. */
+  tileMoveDestinations: AxialCoord[];
+
+  /** Monotonically increasing turn counter (incremented on endTurn). */
+  turnNumber: number;
+
+  /** Board size, objective count, undo enablement, and optional map seed. */
+  gameOptions: GameOptions;
+
+  /**
+   * Stack of reversible action snapshots for the multi-step undo feature.
+   * Empty when undo is disabled or no actions have been taken this turn.
+   */
+  undoStack: UndoSnapshot[];
+
+  /**
+   * Whether an undo action is currently available (derived from undoStack,
+   * retained in G so the engine can expose it without recomputing).
+   */
+  canUndo: boolean;
+}
+
+/**
+ * Fields present in SerializableGameState that are intentionally excluded
+ * from KingdomG (UI-only concerns, not engine domain state):
+ *
+ *   selectedCell    — AxialCoord | null  — UI hex cursor
+ *   validPlacements — AxialCoord[]       — UI cached move hints (recomputed each render)
+ *   history         — GameAction[]       — action log for replay UI only
+ */
+export type ClientOnlyState = {
+  selectedCell: AxialCoord | null;
+  validPlacements: AxialCoord[];
+};


### PR DESCRIPTION
## R5 Phase1 PR-A — KingdomG 純領域型別抽取

### 說明

從 `SerializableGameState`（`src/store/persistence.ts`）提取純遊戲領域狀態 `KingdomG`，剔除 UI 輔助欄位。

### 新增檔案（僅新增，零修改既有檔案）

- `src/engine/types.ts` — `KingdomG` interface + `ClientOnlyState` type
- `src/engine/index.ts` — barrel export（PR-B/C 將繼續擴充）

### KingdomG vs SerializableGameState 欄位差異

**保留（純領域）：**
`board`, `players`, `currentPlayerIndex`, `phase`, `currentTerrainCard`, `remainingPlacements`, `deck`, `acquiredLocations`, `objectiveCards`, `finalScores`, `placementsThisTurn`, `activeTile`, `tileMoveSources`, `tileMoveFrom`, `tileMoveDestinations`, `turnNumber`, `gameOptions`, `undoStack`, `canUndo`

**剔除（UI-only，移至 ClientOnlyState）：**
- `selectedCell: AxialCoord | null` — UI 游標選格，非規則關心
- `validPlacements: AxialCoord[]` — 衍生自 `getValidPlacements()`，UI render cache
- `history: GameAction[]` — action log，僅供 replay UI 使用

### 驗證

- `npx tsc --noEmit` → 零錯誤
- pre-push hook: build OK + 840/840 tests pass
- `git diff --name-only --diff-filter=M main` → 空（零既有檔被修改）

### Live runtime 影響

**零影響。** 純新增型別檔案，未被任何現有 import 引用。

---

**Reviewer: CTO**
⛔ DO NOT MERGE — 待 CEO 親驗 + eye review